### PR TITLE
Return 404 error if fruit does not exist

### DIFF
--- a/docs/topics/crud-experience-intro.adoc
+++ b/docs/topics/crud-experience-intro.adoc
@@ -16,7 +16,7 @@ Specifically, this Booster provides an application that allows you to:
 * Execute an HTTP `GET` request on the `api/fruits/*` endpoint.
 * Receive a response formatted as a JSON array containing the list of all fruits in the database.
 * Execute and HTTP `GET` request on the `api/fruits/*` endpoint while passing in a valid item ID as an argument.
-* Receive a response in JSON format containing the name of the fruit with the given ID. If no item matches the specified ID, you will receive an empty JSON document as a response.
+* Receive a response in JSON format containing the name of the fruit with the given ID. If no item matches the specified ID, the call results in an HTTP error 404.
 * Execute an HTTP `POST` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument, to create a new entry in the database.
 * Execute an HTTP `PUT` request on the `api/fruits/*` endpoint passing in a valid index and a name as an argument. This updates the name of the item with the given ID to match the name specified in your request.
 * Execute an HTTP `DELETE` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument. This removes the item with the specified ID from the database and returns an HTTP code `204` (No Content) as a response. If you pas in an invalid ID, the call results in an HTTP error `404`.


### PR DESCRIPTION
This is not specified in a spec (nor is an empty JSON response) but this is a normal outcome if a resources with a specified id doesn't exist.