### PR TITLE
Removed the -DskipTests property from mvn command

### DIFF
--- a/docs/topics/crud-mission-deploy-booster.adoc
+++ b/docs/topics/crud-mission-deploy-booster.adoc
@@ -48,7 +48,7 @@ Your `my-database` pod should have a status of `Running` and should be indicated
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean fabric8:deploy -Popenshift -DskipTests
+$ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the S2I process on {OpenShiftLocal} and to start the pod.


### PR DESCRIPTION
All the crud boosters have "-DskipTests" in the `mvn clean fabric8:deploy -Popenshift -DskipTests` command in docs (e.g. [spring-boot-crud](http://openshiftio-appdev-docs-appdev-documentation.tsrv.devshift.net/mission-crud-spring-boot-tomcat.html)).

I have tried all the crud boosters without the skip tests option (minishift -> launchpad -> download zip):

```
oc new-app -e POSTGRESQL_USER=luke -ePOSTGRESQL_PASSWORD=secret -ePOSTGRESQL_DATABASE=my_data openshift/postgresql-92-centos7 --name=my-database

mvn clean fabric8:deploy -Popenshift
```
This works as the standalone tests pass (actually only `spring-boot-crud` runs them, see note below), thus we don't need to use the `-DskipTests` property (which is not best practice at all).

*NOTE*:
- `vertx-crud` does not contain standalone tests
- `swarm-crud` has `<skipTests>true</skipTests>` hardcoded in pom.xml