### PR TITLE
Vert.x Config Map Booster consistency fixes

### DIFF
--- a/docs/topics/configmap-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-vertx.adoc
@@ -9,24 +9,44 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 $ curl http://{app-name}-myproject.192.168.99.100.nip.io/api/greeting
 {"content":"Hello, World from a ConfigMap !"}
 ----
-
 . Update the deployed ConfigMap configuration.
 +
-Using your favorite text editor, open `app-config.yml`. Change the value for the `message` key to `Bonjour, %s from a ConfigMap!` and save the file.
-
-. Apply the new version of the ConfigMap configuration.
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc edit configmap app-config
+----
 +
-[source,options="nowrap",subs="attributes+"]
-----
-oc apply -f app-config.yml
-----
+Change the value for the `message` key to `Bonjour, %s from a ConfigMap !` and save the file.
 
+
+. Update of the config map should be read by the application within an acceptable time (a few seconds) without requiring a restart of the application.
 . Use `curl` to execute a `GET` request against the booster with the updated ConfigMap configuration. You can also use a browser to do this.
 +
-[source,options="nowrap",subs="attributes+"]
+[source,bash,options="nowrap",subs="attributes+"]
 ----
 $ curl http://{app-name}-myproject.192.168.99.100.nip.io/api/greeting
 {"content":"Bonjour, World from a ConfigMap !"}
 ----
 +
 You should see your updated greeting.
+
+= Running Integration Tests
+
+This booster contains a set of integration tests.
+To run them, you must be connected to an OpenShift instance and select the project that will be used for testing.
+
+To run the integration tests, execute the following command:
+
+[source,bash,options="nowrap",subs="attributes+"]
+--
+$ mvn clean verify -Popenshift,openshift-it
+--
+[WARNING]
+--
+Be sure that view access rights for service account are added before executing tests.
+
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc policy add-role-to-user view -n $(oc project -q) -z default
+----
+--

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -119,8 +119,8 @@ endif::configmap-vertx[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc get routes
-NAME                           HOST/PORT                                     PATH      SERVICES             PORT      TERMINATION
-{app-name}   {app-name}-myproject.192.168.99.100.nip.io      {app-name}   8080
+NAME         HOST/PORT                                     PATH      SERVICES             PORT      TERMINATION
+{app-name}   {app-name}-myproject.192.168.99.100.nip.io              {app-name}           8080
 ----
 +
 A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-myproject.192.168.99.100.nip.io` as the base URL to access the application.


### PR DESCRIPTION
* Change acceptance criteria for Vert.x booster
* Explain integration test execution
* Make [source] tags consistent
* change of CFG map is now consistent with other boosters
* reallign `oc get routes` output
