### PR TITLE
Rendering issue for html elements in health check booster

### DIFF
--- a/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -24,7 +24,7 @@ $ curl http://{app-name}-myproject.192.168.64.3.nip.io/api/greeting
 +
 Invoking the /api/killme endpoint simulates an internal service failure and triggers the OpenShift self-healing capabilities. When invoking /api/greeting after simulating the failure, the service should return a HTTP status 503.
 +
-[source,option="nowrap",subs="attributes"]
+[source,option="nowrap",subs="attributes+"]
 ----
 $ curl http://{app-name}-myproject.192.168.64.3.nip.io/api/killme
 

--- a/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
@@ -14,7 +14,7 @@ $ curl http://{app-name}-myproject.192.168.64.3.nip.io/api/greeting
 
 . To simulate a service internal failure and to trigger the openshift selfhealing capabilities, invoke the `/api/killme` endpoint and verify the availability of the `/api/greeting` endpoint shortly after that. It should return a HTTP status 503:
 +
-[source,option="nowrap",subs="attributes"]
+[source,option="nowrap",subs="attributes+"]
 ----
 $ curl http://{app-name}-myproject.192.168.64.3.nip.io/api/killme
 


### PR DESCRIPTION
Html elements was not rendered previously:
```
<html>
  <head><title>Error</title></head>
  <body>503 - Service Unavailable</body>
</html>
```
was rendered as:
```
  

  503 - Service Unavailable


```