### PR TITLE
[http-api] Added integration tests section. Removed -DskipTests from mvn.

### DIFF
--- a/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -19,3 +19,15 @@ $ curl http://{app-name}-myproject.192.168.99.100.nip.io/api/greeting?name=Sarah
 ----
 
 include::rest-level-0-mission-form-note.adoc[leveloffset=+1]
+
+= Running Integration Tests
+
+This booster contains a set of integration tests.
+To run them, you must be connected to an OpenShift instance and select the project that will be used for testing.
+
+To run the integration tests, execute the following command:
+
+[source,bash,option="nowrap"]
+--
+$ mvn clean verify -Popenshift,openshift-it
+--

--- a/docs/topics/rest-level-0-mission-deploy-booster.adoc
+++ b/docs/topics/rest-level-0-mission-deploy-booster.adoc
@@ -30,7 +30,7 @@ $ oc new-project NEW-PROJECT-NAME
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean fabric8:deploy -Popenshift -DskipTests
+$ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the S2I process on {OpenShiftLocal} and to start the pod.


### PR DESCRIPTION
ad -DskipTests)
I have tested the `mvn clean fabric8:deploy -Popenshift` (no -DskipTests) with all boosters, thus we can remove it.

ad integration tests section)
Tested with spring-boot-http-booster

If the formatting is wrong or anything else, I will change it according to your comments.