### PR TITLE
[spring-boot-configmap] Updated spring-boot configmap docs.

### DIFF
--- a/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -47,3 +47,24 @@ $ curl http://{app-name}-myproject.192.168.99.100.nip.io/api/greeting
 ----
 +
 You should see your updated greeting.
+
+= Running Integration Tests
+
+This booster contains a set of integration tests.
+To run them, you must be connected to an OpenShift instance and select the project that will be used for testing.
+
+To run the integration tests, execute the following command:
+
+[source,bash,options="nowrap",subs="attributes+"]
+--
+$ mvn clean verify -Popenshift,openshift-it
+--
+[WARNING]
+--
+Be sure that view access rights for service account are added before executing tests.
+
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc policy add-role-to-user view -n $(oc project -q) -z default
+----
+--

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -24,14 +24,14 @@ $ oc login {link-osl-auth} --token=MYTOKEN
 $ oc new-project NEW-PROJECT-NAME
 ----
 
-ifdef::configmap-vertx[]
+ifdef::configmap-vertx,configmap-spring-boot-tomcat[]
 . Add a policy for the project.
 +
 [source,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::configmap-vertx[]
+endif::configmap-vertx,configmap-spring-boot-tomcat[]
 
 . Navigate to the root directory of your booster.
 
@@ -82,18 +82,18 @@ endif::configmap-wf-swarm[]
 
 . Use maven to start the deployment to {OpenShiftLocal}.
 +
-ifdef::configmap-vertx[]
+ifdef::configmap-vertx,configmap-spring-boot-tomcat[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift
 ----
-endif::configmap-vertx[]
-ifndef::configmap-vertx[]
+endif::configmap-vertx,configmap-spring-boot-tomcat[]
+ifdef::configmap-wf-swarm[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift -DskipTests
 ----
-endif::configmap-vertx[]
+endif::configmap-wf-swarm[]
 +
 This command uses the Fabric8 Maven Plugin to launch the S2I process on {OpenShiftLocal} and to start the pod.
 


### PR DESCRIPTION
Verified with https://github.com/snowdrop/spring-boot-configmap-booster master. I assume that configmap will be a part of summit release as [OBST-219](https://issues.jboss.org/browse/OBST-219) has been closed.