### PR TITLE
Correct reason given for browser security warning

### DIFF
--- a/docs/topics/minishift-install-start-configure-minishift.adoc
+++ b/docs/topics/minishift-install-start-configure-minishift.adoc
@@ -37,7 +37,7 @@ image::minishift_login.png[Login]
 +
 [NOTE]
 ====
-Since {OpenShiftLocal} is for development purposes, it uses HTTPS for the web console but does not provide a certificate. You may need to allow your browser to bypass SSL security policies as it tries to protect you from using `HTTPS` without a certificate. The below screenshot shows the warning message in the Chrome browser.
+Since {OpenShiftLocal} is for development purposes, it uses HTTPS for the web console and only provides a self-signed certificate. You may need to allow your browser to bypass SSL security policies as it tries to protect you from using `HTTPS` without a cerficate signed by a certificate authority. The below screenshot shows the warning message in the Chrome browser.
 
 image::minishift_sslwarning.png[SSL warning]
 ====


### PR DESCRIPTION
Part of Obsidian security review by Red Hat Product Security