### PR TITLE
Update requirement to Minishift 1.0.0

### DIFF
--- a/docs/topics/minishift-install-prereq.adoc
+++ b/docs/topics/minishift-install-prereq.adoc
@@ -7,7 +7,7 @@ To verify you have {OpenShiftLocal} installed and configured:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ minishift version
-Minishift version: 1.0.0-beta5
+Minishift version: 1.0.0
 ----
 
 You also need to have the `oc` binary setup on your path as detailed link:https://docs.openshift.org/latest/minishift/getting-started/quickstart.html#starting-minishift[here]. To verify you have `oc` on your path:
@@ -15,7 +15,7 @@ You also need to have the `oc` binary setup on your path as detailed link:https:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc version
-oc v1.4.1+3f9807a
-kubernetes v1.4.0+776c994
-features: Basic-Auth
+oc v1.5.0
+kubernetes v1.5.2+43a9be4
+features: Basic-Auth GSSAPI Kerberos SPNEGO
 ----

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -43,7 +43,7 @@
 :getting-started-guide-name: Getting Started Guide
 :landing-page-name: Welcome
 
-:MinishiftVersion: v1.0.0-beta.5
+:MinishiftVersion: 1.0.0
 
 :mission-crud-spring-boot-tomcat-guide-name: CRUD Mission - {SpringBoot}
 :mission-crud-vertx-guide-name: CRUD Mission - {VertX}


### PR DESCRIPTION
This PR upgrades the docs to require Minishift 1.0.0 instead of 1.0.0-beta5