### PR TITLE
clarify the wording about JPA and ORM

### DIFF
--- a/docs/topics/crud-mission-design-tradeoffs.adoc
+++ b/docs/topics/crud-mission-design-tradeoffs.adoc
@@ -2,7 +2,7 @@
 [width="100%",options="header"]
 |====================================================================
 |Pros           |Cons
-a| * Each runtime decides how the database interactions are implemented. One can use JDBC while others can use JPA or an ORM. Each runtime decides what would be the best way.
+a| * Each runtime decides how the database interactions are implemented. One can use JDBC while others can use JPA or access ORM APIs directly. Each runtime decides what would be the best way.
 
  * Each runtime decides how the schema is going to be created.
 a|

--- a/docs/topics/crud-mission-intro.adoc
+++ b/docs/topics/crud-mission-intro.adoc
@@ -1,16 +1,16 @@
 include::crud-mission-intro-paragraph.adoc[]
 
-The Booster also demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift. Each runtime determines in an opinionated manner to implement the connectivity solution that is best suited in the given case. The runtime can choose between using _JDBC_, _JPA_, or an _ORM_.
+The Booster also demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift. Each runtime determines in an opinionated manner to implement the connectivity solution that is best suited in the given case. The runtime can choose between using _JDBC_, _JPA_, or access _ORM_ APIs directly.
 
 The Booster application exposes an HTTP _CRUD_ API, which provides endpoints that allow you to manipulate data by performing  _CRUD_ operations over HTTP. The _CRUD_ operations are mapped to HTTP `Verbs`. The API uses JSON formatting to receive requests and return responses to the user. The user can also use an UI provided by the booster to use the application. Specifically, this Booster provides an application that allows you to:
 
 * Navigate to the application web interface in your browser. This exposes a simple website allowing you to perform _CRUD_ operations on the data in the `my_data` database.
-* Execute an HTTP `GET` request on the `api/fruits/*` endpoint.
+* Execute an HTTP `GET` request on the `api/fruits` endpoint.
 * Receive a response formatted as a JSON array containing the list of all fruits in the database.
 * Execute and HTTP `GET` request on the `api/fruits/*` endpoint while passing in a valid item ID as an argument.
 * Receive a response in JSON format containing the name of the fruit with the given ID. If no item matches the specified ID, the call results in an HTTP error 404.
 * Execute an HTTP `POST` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument, to create a new entry in the database.
-* Execute an HTTP `PUT` request on the `api/fruits/*` endpoint passing in a valid index and a name as an argument. This updates the name of the item with the given ID to match the name specified in your request.
+* Execute an HTTP `PUT` request on the `api/fruits/*` endpoint passing in a valid ID and a name as an argument. This updates the name of the item with the given ID to match the name specified in your request.
 * Execute an HTTP `DELETE` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument. This removes the item with the specified ID from the database and returns an HTTP code `204` (No Content) as a response. If you pass in an invalid ID, the call results in an HTTP error `404`.
 
 This Booster also contains a set of automated xref:crud-integration-testing[integration test] that can be used to verify that the application is fully integrated with the database.


### PR DESCRIPTION
JPA is a specification that certain ORMs adhere to (e.g. Hibernate
or EclipseLink). These ORMs typically also provide their own public
APIs that can be accessed directly. So the relationship between
the JPA and ORM terms is nuanced: they are not quite the same,
but they are not completely unrelated either. This commit tries
to improve the wording in this area.

Also there are some other small fixes in the CRUD mission docs.