### PR TITLE
add a `revnumber` doc attribute when publishing docs

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,6 +2,7 @@ node("docsbuilder-maven") {
   checkout scm
   stage("Build Documentation") {
     sh "pwd && ls -l"
+    sh "echo :revnumber: \$(git rev-parse --short=10 HEAD) >> ./docs/topics/templates/document-attributes.adoc"
     sh "./scripts/buildGuides.sh"
     sh "mkdir -p ci/openshiftio-appdev-docs/src/main/resources/webroot"
     sh "mv ./html/ ./ci/openshiftio-appdev-docs/src/main/resources/webroot/docs"


### PR DESCRIPTION
This approach is a bit dirty and I'm open to better solutions.