### PR TITLE
Externalised launcher template URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ target
 ci/openshiftio-appdev-docs/src/main/resources/webroot
 ci/openshiftio-appdev-docs/.vertx
 Guardfile
+.classpath
+.project
+.settings
+*.orig
+*.swp
+

--- a/ci/openshiftio-appdev-docs/pom.xml
+++ b/ci/openshiftio-appdev-docs/pom.xml
@@ -168,6 +168,11 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
   </build>
 
   <profiles>

--- a/ci/openshiftio-appdev-docs/src/main/java/io/openshift/appdev/documentation/builder/HttpApplication.java
+++ b/ci/openshiftio-appdev-docs/src/main/java/io/openshift/appdev/documentation/builder/HttpApplication.java
@@ -22,10 +22,35 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.RedirectAuthHandler;
 import io.vertx.ext.web.handler.StaticHandler;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
 public class HttpApplication extends AbstractVerticle {
 
-   private static final String INDEX_PAGE = "index.html";
-   private static final String LAUNCHER_TEMPLATE_LATEST_URL = "https://raw.githubusercontent.com/openshiftio/launchpad-templates/v5/openshift/launchpad-template.yaml";
+    private static final String propFileLocation = "src/main/resources/application.properties";
+    private static final Properties props = loadProperties();
+
+    private static Properties loadProperties() {
+        Properties props = new Properties();
+        FileInputStream  ioStream = null;
+        try {
+            ioStream = new FileInputStream(propFileLocation);
+            props.load(ioStream);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (ioStream != null) {
+                try {
+                    ioStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return props;
+    }
+
   @Override
   public void start(Future<Void> future) {
     // Create a router object.
@@ -33,7 +58,7 @@ public class HttpApplication extends AbstractVerticle {
 
     router.get("/health").handler(rc -> rc.response().end("OK"));
     router.get("/latest-launcher-template").handler(rc -> 
-        rc.response().setStatusCode(302).putHeader("Location", LAUNCHER_TEMPLATE_LATEST_URL).end());
+        rc.response().setStatusCode(302).putHeader("Location", props.getProperty("launcher.template_url.latest")).end());
      router.route("/").handler(context -> {
         // Redirect to docs
         context.response().putHeader("location", "/docs").setStatusCode(302).end();
@@ -41,7 +66,7 @@ public class HttpApplication extends AbstractVerticle {
      router.get("/docs/*").handler(
             StaticHandler.create().
                     setWebRoot(StaticHandler.DEFAULT_WEB_ROOT + "/docs").
-                    setIndexPage(INDEX_PAGE));
+                    setIndexPage(props.getProperty("launcher.index_page")));
 
 
 

--- a/ci/openshiftio-appdev-docs/src/main/java/io/openshift/appdev/documentation/builder/HttpApplication.java
+++ b/ci/openshiftio-appdev-docs/src/main/java/io/openshift/appdev/documentation/builder/HttpApplication.java
@@ -22,31 +22,20 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.RedirectAuthHandler;
 import io.vertx.ext.web.handler.StaticHandler;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
 public class HttpApplication extends AbstractVerticle {
 
-    private static final String propFileLocation = "src/main/resources/application.properties";
+    private static final String propFileLocation = "/application.properties";
     private static final Properties props = loadProperties();
 
     private static Properties loadProperties() {
         Properties props = new Properties();
-        FileInputStream  ioStream = null;
         try {
-            ioStream = new FileInputStream(propFileLocation);
-            props.load(ioStream);
+            props.load(HttpApplication.class.getResourceAsStream(propFileLocation));
         } catch (IOException e) {
             e.printStackTrace();
-        } finally {
-            if (ioStream != null) {
-                try {
-                    ioStream.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
         }
         return props;
     }

--- a/ci/openshiftio-appdev-docs/src/main/resources/application.properties
+++ b/ci/openshiftio-appdev-docs/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-launcher.template_url.latest=https\://raw.githubusercontent.com/openshiftio/launchpad-templates/v4/openshift/launchpad-template.yaml
+launcher.template_url.latest=https\://raw.githubusercontent.com/openshiftio/launchpad-templates/v5/openshift/launchpad-template.yaml
 launcher.index_page=index.html

--- a/ci/openshiftio-appdev-docs/src/main/resources/application.properties
+++ b/ci/openshiftio-appdev-docs/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+launcher.template_url.latest=https\://raw.githubusercontent.com/openshiftio/launchpad-templates/v4/openshift/launchpad-template.yaml
+launcher.index_page=index.html


### PR DESCRIPTION
Resolves #142.

In this arrangement, the launcher URL is stored in the `ci/openshiftio-appdev-docs/src/main/resources/application.properties` file under the `launcher.template_url.latest` property. I externalised the `INDEX_PAGE` property to `launcher.index_page` the same way.

If you think the property should be defined in the `pom.xml` file instead, no problem, I'll change it. I am not sure about all the use cases of this product, so I just chose the approach that seemed most bulletproof.