### PR TITLE
Script to tag release + instructions

### DIFF
--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -1,10 +1,31 @@
 # Release Instructions
 
-After the catalog update has been made, update the following lines with the latest version:
+After the catalog update has been made, do the following:
 
+* Update the following lines with the latest version:
++
+--
 * link:https://github.com/openshiftio/appdev-documentation/blob/master/scripts/deploy_launchpad_mission.sh#L16[Catalog Version in Build Script]
 * link:https://github.com/openshiftio/appdev-documentation/blob/master/ci/openshiftio-appdev-docs/src/main/java/io/openshift/appdev/documentation/builder/HttpApplication.java#L27[Link to Launchpad Template YAML file in Vert.X Link Indirection]
 
 Usually, this will mean going from `vX` to `vX+1` e.g. `v3` to `v4`.
 
 To get this update merged, follow the _Contributing_ process outlined in the link:https://github.com/openshiftio/appdev-documentation/blob/master/README.adoc[README] file of the repo. This update can happen anytime after the catalog has been updated, including after the release train has been completed. 
+--
+
+* Tag the commit you are releasing. Execute this script in the `$REPO_HOME/scripts` directory:
++
+--
+[source,bash]
+----
+$ ./tagRelease.sh
+----
+
+The script automatically tags the commit with the current date in the `YYYY-MM-DD` format. If you are re-releasing the same day, a suffix `_2`, `_3`, etc. is appended. If you want to tag with a different date, do so manually:
+
+[source,bash]
+----
+$ git tag 2017-04-21
+----
+--
+

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,7 +2,7 @@ node("docsbuilder-maven") {
   checkout scm
   stage("Build Documentation") {
     sh "pwd && ls -l"
-    sh "echo :revnumber: \$(git rev-parse --short=10 HEAD) >> ./docs/topics/templates/document-attributes.adoc"
+    sh "echo :revnumber: \$(git name-rev --tags --name-only --no-undefined HEAD) >> ./docs/topics/templates/document-attributes.adoc"
     sh "echo :SegmentTrackerToken: \$LAUNCHPAD_TRACKER_SEGMENT_TOKEN >> ./docs/topics/templates/document-attributes.adoc"
     sh "./scripts/buildGuides.sh"
     sh "mkdir -p ci/openshiftio-appdev-docs/src/main/resources/webroot"

--- a/scripts/tagRelease.sh
+++ b/scripts/tagRelease.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Not tagging if HEAD is already tagged
+if git name-rev --tags --name-only --no-undefined HEAD &>/dev/null; then
+	read -p "Your latest commit is tagged. Do you really want to re-tag? [yN] " choice
+	case $choice in
+		[Yy] ) :;;
+		* ) exit;;
+	esac
+fi
+
+# Parsing current tag
+
+# Using name-rev is not good because it only gives you one tag, and not
+# necessary the latest version
+today_tag="$(date --rfc-3339=date)"
+latest_today_tag="$(git tag | grep "$today_tag" | sort | tail -1)"
+suffix="$(echo $latest_today_tag | awk -F '_' '{print $2}')"
+
+# We released exactly once today
+if [ "$latest_today_tag" == "$today_tag" ]; then
+	tag="${today_tag}_2"
+# We released today at least twice
+elif [ "$suffix" != "" ]; then
+	tag="${today_tag}_$((suffix+1))"
+# We have not released today yet
+else
+	tag="${today_tag}"
+fi
+
+echo Tagging with "${tag}".
+git tag "${tag}"
+


### PR DESCRIPTION
The script automatically creates and applies the correct tag:

* `YYYY-MM-DD` if there hasn't been a release that day.
* `YYYY-MM-DD_NUMBER` if there has. `NUMBER` starts at 2 and is automatically incremented.

Known issues:

* The detection of the latest tag of today (line 17) does not work well when there has been more releases than 9.

Resolves #328.