### PR TITLE
Added Travis config and CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+before_install:
+    - sudo apt-get install libxml2-utils
+install:
+    - gem install asciidoctor
+script: ./scripts/buildGuides-CI.sh

--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -5,7 +5,11 @@ include::topics/templates/document-attributes.adoc[]
 
 == {launcher} Development
 
+_TBD_
+
 == File a Code Issue
+
+_TBD_
 
 == Documentation
 
@@ -46,3 +50,5 @@ include::topics/contributing-labels.adoc[leveloffset=+3]
 
 [appendix]
 == Upstream Runtime Project Development Resources
+
+_TBD_

--- a/scripts/buildGuides-CI.sh
+++ b/scripts/buildGuides-CI.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+
+failed_builds=""
+failed_validations=""
+exit_status=0
+
+for dir in $(dirname docs/*/master.adoc); do
+    echo -e "\nBuilding $dir"
+    pushd $dir >/dev/null
+
+    # Check if this book is ignored in the CI builds
+    if test -e .ci-ignore; then
+        popd >/dev/null
+        continue
+    fi
+
+    # Build title into DocBook XML and see if any errors or warnings were output
+    if asciidoctor master.adoc -b docbook5 2>&1 | grep "ERROR\|WARNING"; then
+        echo -e "Failed to build $dir."
+        failed_builds="$failed_builds $dir"
+        popd >/dev/null
+        continue
+    fi
+
+    # Validate the DocBook XML
+    if ! xmllint --schema http://docbook.org/xml/5.0/xsd/docbook.xsd master.xml 1>/dev/null; then
+        echo "Failed to validate $dir."
+        failed_validations="$failed_validations $dir"
+    fi
+    popd >/dev/null
+done
+
+echo
+
+# Output failed builds
+if test -n "$failed_builds"; then
+    exit_status=$((exit_status+1))
+    echo -e "\nFailed builds:"
+    for failed_build in $failed_builds; do
+        echo " * $failed_build"
+    done
+fi
+
+# Output failed validations
+if test -n "$failed_validations"; then
+    exit_status=$((exit_status+1))
+    echo -e "Failed validations:"
+    for validation in $failed_validations; do
+        echo " * $validation"
+    done
+fi
+
+exit $exit_status
+


### PR DESCRIPTION
Explanation:

* `.travis.yml` is the Travis CI (travis-ci.org) configuration file.
* The `buildGuides-CI.sh` script builds all titles (subdirectories of `docs` that have `master.adoc` in them) into DocBook 5 XMLs and validates them using XMLlint.
  * Since AsciiDoctor returns zero almost every time, I opted for grepping for warnings and errors in its output instead. This still doesn't catch missing images, though. I'm open to changing this.
  * Titles that have the `.ci-ignore` file in their directory are ignored. This is an arbitrary mechanism I put here since we need a way of excluding e. g. the Landing Page from the checking. The reason is that its sources contain the `<link>` element for CSS, which works in the HTML output, but does not validate in the DocBook XML output.
  * Books that failed building or validation are displayed at the end of the script run in a list for easy reading. You can then either rebuild them locally or look at the CI build log to see what went wrong.
* Empty chapters in the Contribution Guide were causing validation errors, so I fixed that by adding _TBD_ to them.

Next steps:

* Someone with owner access to the repository needs to log into travis-ci.org and enable Travis building for `appdev-documentation`.

Other:

* You can preview how a Travis build looks in my personal repo: https://github.com/tradej/appdev-documentation/pull/1 (click on _Show all checks_ → _Details_ to get to the Travis builds). I have set that pull request up only for show, I will close it later of course.

Resolves #297.