### PR TITLE
Release tagging script and instructions

### DIFF
--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -1,7 +1,10 @@
 # Release Instructions
 
-After the catalog update has been made, update the following lines with the latest version:
+After the catalog update has been made, do the following:
 
+* Update the following lines with the latest version:
++
+--
 * link:https://github.com/openshiftio/appdev-documentation/blob/master/scripts/deploy_launchpad_mission.sh#L16[Catalog Version in Build Script]
 * link:https://github.com/openshiftio/appdev-documentation/blob/master/ci/openshiftio-appdev-docs/src/main/resources/application.properties#L1[Link to Launchpad Template YAML file in Vert.X Link Indirection]
 * link:https://github.com/openshiftio/appdev-documentation/blob/master/docs/topics/minishift-install-create-launchpad-app-script.adoc#L33[Update Install Instructions when using the `-v` option]
@@ -10,3 +13,33 @@ After the catalog update has been made, update the following lines with the late
 Usually, this will mean going from `vX` to `vX+1` e.g. `v3` to `v4`.
 
 To get this update merged, follow the _Contributing_ process outlined in the link:https://github.com/openshiftio/appdev-documentation/blob/master/README.adoc[README] file of the repo. This update can happen anytime after the catalog has been updated, including after the release train has been completed. 
+--
+
+* Tag the commit you are releasing. Execute the `tagRelease.sh` script in the `$REPO_HOME/scripts` directory on the `production` branch:
++
+--
+[source,bash]
+----
+$ git checkout production
+$ ./tagRelease.sh
+----
+
+The script automatically tags the commit with the current date in the `YYYY-MM-DD` format. If you are re-releasing the same day, a suffix `_2`, `_3`, etc. is appended. If you want to tag with a different date, do so manually:
+
+[source,bash]
+----
+$ git tag 2017-04-21
+----
+--
+
+* Push the tags:
++
+--
+[source,bash]
+----
+$ git push --tags $REMOTE
+----
+
+Replace `$REMOTE` with the name of the upstream remote
+--
+

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,7 +2,7 @@ node("docsbuilder-maven") {
   checkout scm
   stage("Build Documentation") {
     sh "pwd && ls -l"
-    sh "echo :revnumber: \$(git rev-parse --short=10 HEAD) >> ./docs/topics/templates/document-attributes.adoc"
+    sh "echo :revnumber: \$(date --rfc-3339=date) >> ./docs/topics/templates/document-attributes.adoc"
     sh "echo :SegmentTrackerToken: \$LAUNCHPAD_TRACKER_SEGMENT_TOKEN >> ./docs/topics/templates/document-attributes.adoc"
     sh "./scripts/buildGuides.sh"
     sh "mkdir -p ci/openshiftio-appdev-docs/src/main/resources/webroot"

--- a/scripts/tagRelease.sh
+++ b/scripts/tagRelease.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Not tagging if HEAD is already tagged
+if git name-rev --tags --name-only --no-undefined HEAD &>/dev/null; then
+	read -p "Your latest commit is tagged. Do you really want to re-tag? [yN] " choice
+	case $choice in
+		[Yy] ) :;;
+		* ) exit;;
+	esac
+fi
+
+# Parsing current tag
+
+# Using name-rev is not good because it only gives you one tag, and not
+# necessary the latest version
+today_tag="$(date --rfc-3339=date)"
+latest_today_tag="$(git tag | grep "$today_tag" | sort | tail -1)"
+suffix="$(echo $latest_today_tag | awk -F '_' '{print $2}')"
+
+# We released exactly once today
+if [ "$latest_today_tag" == "$today_tag" ]; then
+	tag="${today_tag}_2"
+# We released today at least twice
+elif [ "$suffix" != "" ]; then
+	tag="${today_tag}_$((suffix+1))"
+# We have not released today yet
+else
+	tag="${today_tag}"
+fi
+
+echo Tagging with "${tag}".
+echo Do not forget to push the tags: git push --tags \$REMOTE
+
+git tag "${tag}"


### PR DESCRIPTION
 **Please re-review**.

Changes:

* RELEASE.adoc updated with information about how to tag
* Added the tagRelease.sh script
* Jenkins includes RFC 3339 date instead of the commit hash

Main difference from the previous (reverted) solution: tagging is manual (the same script is used as before, run it on the `production` branch after master has been merged in) and Jenkins puts the current date instead of the latest tag into the `:revnumber:` attribute. I know it is not as bulletproof as intended, but I think it should do for now, or at least until we find out a better way to automate the process.

Resolves #328.