### PR TITLE
Added info about expected proficiency to missions

### DIFF
--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -42,3 +42,6 @@ include::topics/http-api-nodejs-package-json.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/nodejs-dev-guide-additional-resources.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -140,3 +140,6 @@ include::topics/http-api-spring-boot-pom.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/sb-tomcat-dev-guide-additional-resources.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]

--- a/docs/topics/appendix-proficiency-levels.adoc
+++ b/docs/topics/appendix-proficiency-levels.adoc
@@ -1,0 +1,21 @@
+
+[[proficiency_levels]]
+= Proficiency Levels
+
+Each mission available on {launcher} teaches you about certain topics, but requires certain minimum knowledge, which varies by mission. For clarity, the minimum requirements and concepts are organized in several proficiency levels. In addition to the levels described in this chapter, there can be additional requirements with each mission, specific to its aim or the technologies it uses.
+
+[discrete]
+== {proficiency-foundational}
+
+The missions rated at {proficiency-foundational} proficiency generally require no prior knowledge of the subject matter; they provide general awareness and demonstration of key elements, concepts, and terminology. There are no special requirements except those directly mentioned in the description of the mission.
+
+[discrete]
+== {proficiency-advanced}
+
+When using {proficiency-advanced} missions, the assumption is that you are familiar with the common concepts and terminology of the subject area of the mission in addition to Kubernetes and OpenShift. You must also be able to perform basic tasks on your own, for example configure services and applications, or administer networks. If a service is needed by the mission, but configuring it is not in the scope of the mission, the assumption is that you have the knowledge to to properly configure it, and only the resulting state of the service is described in the documentation.
+
+[discrete]
+== {proficiency-expert}
+
+{proficiency-expert} missions require the highest level of knowledge of the subject matter. You are expected to perform many tasks based on feature-based documentation and manuals, and the documentation is aimed at most complex scenarios.
+

--- a/docs/topics/circuit-breaker-mission-intro-paragraph.adoc
+++ b/docs/topics/circuit-breaker-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 The _Circuit Breaker_ Mission demonstrates a generic pattern for reporting the failure of a service and then limiting access to the failed service until it becomes available to handle requests. This helps prevent cascading failure in other services that depend on the failed services for functionality.

--- a/docs/topics/configmap-mission-intro-paragraph.adoc
+++ b/docs/topics/configmap-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 The ConfigMap Mission provides a basic example of using ConfigMap to take advantage of external configuration sources.

--- a/docs/topics/crud-mission-intro-paragraph.adoc
+++ b/docs/topics/crud-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 The Relational Database Backend Booster expands on the {name-mission-http-api} Booster to provide a basic example of performing _create_, _read_, _update_ and _delete_ (_CRUD_) operations on a PostgreSQL database using a simple HTTP API. _CRUD_ operations are the four basic functions of persistent storage, widely used when developing HTTP API dealing with a database.

--- a/docs/topics/health-check-mission-intro-paragraph.adoc
+++ b/docs/topics/health-check-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 When you deploy an application, its important to know if it is available and if it can start handling incoming requests. Implementing the _health check_ pattern allows you to monitor the health of an application, which includes if an application is available and whether it is able to service requests.

--- a/docs/topics/rest-level-0-mission-intro-paragraph.adoc
+++ b/docs/topics/rest-level-0-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 The {name-mission-http-api} Mission provides a basic example of mapping business operations to a remote procedure call endpoint over HTTP using a REST framework. This corresponds to link:https://martinfowler.com/articles/richardsonMaturityModel.html#level0[Level 0 in the Richardson Maturity Model]. Creating an HTTP endpoint using REST and its underlying principals to define your API enables you to quickly prototype and design your API in a flexible manner.

--- a/docs/topics/secured-mission-intro-paragraph.adoc
+++ b/docs/topics/secured-mission-intro-paragraph.adoc
@@ -1,1 +1,3 @@
+Mission proficiency level: *{proficiency-foundational}*. For more information, see xref:proficiency_levels[].
+
 The Secured Booster expands on the {name-mission-http-api} Booster by securing a REST endpoint using link:https://access.redhat.com/products/red-hat-single-sign-on[{RHSSO}]. {RHSSO} implements the OAuth 2.0 specification and uses it to issue access tokens to provide clients with various access rights to secured resources. Securing an application with SSO enables you to add security to your applications while centralizing the security configuration.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -121,3 +121,11 @@
 :oso-route-hostname: OPENSHIFT_ONLINE_HOSTNAME
 
 :link-launcher-install-script: https://raw.githubusercontent.com/openshiftio/appdev-documentation/production/scripts/deploy_launchpad_mission.sh
+
+
+// Mission Knowledge Proficiency
+// Usage expects all of these to be capitalized
+:proficiency-foundational: Foundational
+:proficiency-advanced: Advanced
+:proficiency-expert: Expert
+

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -141,3 +141,6 @@ include::topics/http-api-vertx-pom.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/vertx-dev-guide-additional-resources.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -141,3 +141,6 @@ include::topics/http-api-wf-swarm-pom.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/wf-swarm-dev-guide-additional-resources.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]


### PR DESCRIPTION
* Every runtime book now has an extra appendix describing the proficiency levels.
* Every mission's intro paragraph starts with the information about the exptected proficiency.
* At the moment, I have assigned all missions the "Foundational" level.
* I am using attributes in case we want to change the wording.

Please provide feedback, thank you.

Resolves #64.