### PR TITLE
Fixed date format in Jenkinsfile and tagRelease.sh

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,7 +2,7 @@ node("docsbuilder-maven") {
   checkout scm
   stage("Build Documentation") {
     sh "pwd && ls -l"
-    sh "echo :revnumber: \$(date --rfc-3339=date) >> ./docs/topics/templates/document-attributes.adoc"
+    sh "echo :revnumber: \$(date '+%Y-%m-%d') >> ./docs/topics/templates/document-attributes.adoc"
     sh "echo :SegmentTrackerToken: \$LAUNCHPAD_TRACKER_SEGMENT_TOKEN >> ./docs/topics/templates/document-attributes.adoc"
     sh "./scripts/buildGuides.sh"
     sh "mkdir -p ci/openshiftio-appdev-docs/src/main/resources/webroot"

--- a/scripts/tagRelease.sh
+++ b/scripts/tagRelease.sh
@@ -13,7 +13,7 @@ fi
 
 # Using name-rev is not good because it only gives you one tag, and not
 # necessary the latest version
-today_tag="$(date --rfc-3339=date)"
+today_tag="$(date '+%Y-%m-%d')"
 latest_today_tag="$(git tag | grep "$today_tag" | sort | tail -1)"
 suffix="$(echo $latest_today_tag | awk -F '_' '{print $2}')"
 


### PR DESCRIPTION
Fixed the date invocation once again. Now it should work, originally I used double quotes that messed up the strings.

Follows up on #392.