### PR TITLE
Issue #374: Externalize Minishift and OSO Route Hostnames

### DIFF
--- a/docs/topics/booster-deploy-openshift-local.adoc
+++ b/docs/topics/booster-deploy-openshift-local.adoc
@@ -12,7 +12,7 @@
 -- Server Information ...
    OpenShift server started.
    The server is accessible via web console at:
-       https://192.168.99.100:8443
+       https://192.168.42.152:8443
 
    You are logged in as:
        User:     developer
@@ -29,4 +29,4 @@ navigate to it in {OpenShiftLocal} and use it to create and launch your booster.
 
 == Deploy Using the `oc` CLI Client
 
-You can deploy your booster to {OpenShiftLocal} by following the same process as deploying a booster to {OpenShiftOnline}, but instead of using a {OpenShiftOnline} URL, use your {OpenShiftLocal} URL to access the Web console and with the `oc` CLI client. 
+You can deploy your booster to {OpenShiftLocal} by following the same process as deploying a booster to {OpenShiftOnline}, but instead of using a {OpenShiftOnline} URL, use your {OpenShiftLocal} URL to access the Web console and with the `oc` CLI client.

--- a/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-spring-boot.adoc
+++ b/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-spring-boot.adoc
@@ -44,7 +44,7 @@ $ oc new-app --template=hystrix-dashboard
 --
 $ oc get route hystrix-dashboard
 NAME                HOST/PORT                                                    PATH      SERVICES            PORT      TERMINATION   WILDCARD
-hystrix-dashboard   hystrix-dashboard-{project-name}.192.168.42.158.nip.io                 hystrix-dashboard   <all>                   None
+hystrix-dashboard   hystrix-dashboard-{project-name}.{osl-route-hostname}                 hystrix-dashboard   <all>                   None
 --
 +
 . To access the Dashboard, open the Dashboard application route URL in your browser. Alternatively, you can navigate to the _Overview_ screen in the Web console and click the route URL in the header above the pod containing your Hystrix Dashboard application.

--- a/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-vertx.adoc
+++ b/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-vertx.adoc
@@ -45,7 +45,7 @@ oc new-app --template=hystrix-dashboard
 --
 oc get route hystrix-dashboard
 NAME                HOST/PORT                                                    PATH      SERVICES            PORT      TERMINATION   WILDCARD
-hystrix-dashboard   hystrix-dashboard-{project-name}.192.168.42.158.nip.io                 hystrix-dashboard   <all>                   None
+hystrix-dashboard   hystrix-dashboard-{project-name}.{osl-route-hostname}                 hystrix-dashboard   <all>                   None
 --
 +
 . To access the Dashboard, open the Dashboard application route URL in your browser. Alternatively, you can navigate to the _Overview_ screen in the Web console and click the route URL in the header above the pod containing your Hystrix Dashboard application.

--- a/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-wf-swarm.adoc
+++ b/docs/topics/circuit-breaker-mission-access-hystrix-dashboard-wf-swarm.adoc
@@ -45,7 +45,7 @@ oc new-app --template=hystrix-dashboard
 --
 oc get route hystrix-dashboard
 NAME                HOST/PORT                                                    PATH      SERVICES            PORT      TERMINATION   WILDCARD
-hystrix-dashboard   hystrix-dashboard-{project-name}.192.168.42.158.nip.io                 hystrix-dashboard   <all>                   None
+hystrix-dashboard   hystrix-dashboard-{project-name}.{osl-route-hostname}                 hystrix-dashboard   <all>                   None
 --
 +
 . To access the Dashboard, open the Dashboard application route URL in your browser. Alternatively, you can navigate to the _Overview_ screen in the Web console and click the route URL in the header above the pod containing your Hystrix Dashboard application.

--- a/docs/topics/circuit-breaker-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -44,7 +44,7 @@ NOTE: The following steps use the command line to interact with the service. Alt
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 +
@@ -59,14 +59,14 @@ $ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshif
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . The Circuit Breaker state indicator in the web interface changes from `CLOSED` to `OPEN` and the Circuit Breaker issues the fallback response when you invoke the `/api/greeting` endpoint.
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, Fallback!"}
 ----
 +
@@ -79,7 +79,7 @@ To do this you can:
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . Invoke the `/api/greeting` endpoint again.
@@ -87,7 +87,7 @@ If the `{app-name}-name` service is available, you should receive the `Hello Wor
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-vertx.adoc
@@ -42,7 +42,7 @@ NOTE: The following steps use the command line to interact with the service. Alt
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 +
@@ -57,14 +57,14 @@ $ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshif
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . The Circuit Breaker state indicator in the web interface changes from `CLOSED` to `OPEN` and the Circuit Breaker issues the fallback response when you invoke the `/api/greeting` endpoint.
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, Fallback!"}
 ----
 +
@@ -77,7 +77,7 @@ To do this you can:
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . Invoke the `/api/greeting` endpoint again.
@@ -85,7 +85,7 @@ If the `{app-name}-name` service is available, you should receive the `Hello Wor
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-wf-swarm.adoc
@@ -42,7 +42,7 @@ NOTE: The following steps use the command line to interact with the service. Alt
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 +
@@ -57,14 +57,14 @@ $ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshif
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . The Circuit Breaker state indicator in the web interface changes from `CLOSED` to `OPEN` and the Circuit Breaker issues the fallback response when you invoke the `/api/greeting` endpoint.
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, Fallback!"}
 ----
 +
@@ -77,7 +77,7 @@ To do this you can:
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.{oso-route-hostname}/api/state
 ----
 +
 . Invoke the `/api/greeting` endpoint again.
@@ -85,7 +85,7 @@ If the `{app-name}-name` service is available, you should receive the `Hello Wor
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-greeting-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 

--- a/docs/topics/circuit-breaker-mission-deploy-booster.adoc
+++ b/docs/topics/circuit-breaker-mission-deploy-booster.adoc
@@ -57,10 +57,10 @@ Both the `{app-name}-greeting` and `{app-name}-name` pods should have a status o
 ----
 $ oc get routes
 NAME                     HOST/PORT                                                        PATH      SERVICES              PORT      TERMINATION   WILDCARD
-{app-name}-greeting   {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com            {app-name}-greeting   8080                    None
-{app-name}-name       {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com            {app-name}-name       8080                    None
+{app-name}-greeting   {app-name}-{project-name}.{oso-route-hostname}            {app-name}-greeting   8080                    None
+{app-name}-name       {app-name}-{project-name}.{oso-route-hostname}            {app-name}-name       8080                    None
 ----
 +
-A pod's route information gives you the base URL which you use to access it. In the example above, you would use `+++http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com+++` as the base URL to access the applications.
+A pod's route information gives you the base URL which you use to access it. In the example above, you would use `+++http://{app-name}-{project-name}.{oso-route-hostname}+++` as the base URL to access the applications.
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]

--- a/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 ----
 
@@ -42,7 +42,7 @@ You `{app-name}-1-aaaaa` pod should have a status of `Running` once it's fully d
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Bonjour!"}
 ----
 +

--- a/docs/topics/configmap-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-vertx.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World from a ConfigMap !"}
 ----
 . Update the deployed ConfigMap configuration.
@@ -24,7 +24,7 @@ Change the value for the `message` key to `Bonjour, %s from a ConfigMap !` and s
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Bonjour, World from a ConfigMap !"}
 ----
 +

--- a/docs/topics/configmap-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-wf-swarm.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 ----
 
@@ -42,7 +42,7 @@ You `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully de
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Bonjour World from a ConfigMap!"}
 ----
 +

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -141,9 +141,9 @@ endif::configmap-vertx[]
 ----
 $ oc get routes
 NAME         HOST/PORT                                     PATH      SERVICES             PORT      TERMINATION
-{app-name}   {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com              {app-name}           8080
+{app-name}   {app-name}-{project-name}.{oso-route-hostname}              {app-name}           8080
 ----
 +
-A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com` as the base URL to access the application.
+A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.{oso-route-hostname}` as the base URL to access the application.
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]

--- a/docs/topics/crud-mission-database-interaction.adoc
+++ b/docs/topics/crud-mission-database-interaction.adoc
@@ -10,14 +10,14 @@ oc get route {app-name} -o jsonpath={$.spec.host}
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
+{app-name}-{project-name}.{oso-route-hostname}
 ----
 
 . To access the web interface of the database application, navigate to the _application URL_ in your browser:
 +
 [source,bash,subs="attributes+"]
 --
-http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
+http://{app-name}-{project-name}.{oso-route-hostname}
 --
 +
 Alternatively, you can make requests directly on the `api/fruits/*` endpoint using `curl`:
@@ -25,7 +25,7 @@ Alternatively, you can make requests directly on the `api/fruits/*` endpoint usi
 .List all entries in the database:
 [source,bash,subs="attributes+"]
 --
-curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/fruits
+curl http://{app-name}-{project-name}.{oso-route-hostname}/api/fruits
 --
 +
 ----
@@ -44,7 +44,7 @@ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/a
 .Retrieve an entry with a specific ID
 [source,bash,options="nowrap",subs="attributes+"]
 --
-curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/fruits/3
+curl http://{app-name}-{project-name}.{oso-route-hostname}/api/fruits/3
 --
 +
 ----
@@ -58,7 +58,7 @@ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/a
 .Create a new entry:
 [source,bash,options="nowrap",subs="attributes+"]
 --
-curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/fruits
+curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://{app-name}-{project-name}.{oso-route-hostname}/api/fruits
 --
 +
 ----
@@ -71,7 +71,7 @@ curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://{
 .Update an Entry
 [source,bash,options="nowrap",subs="attributes+"]
 --
-curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/fruits/1
+curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http://{app-name}-{project-name}.{oso-route-hostname}/api/fruits/1
 --
 +
 ----
@@ -84,7 +84,7 @@ curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http:
 .Delete an Entry:
 [source,bash,options="nowrap",subs="attributes+"]
 --
-curl -X DELETE http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/fruits/1
+curl -X DELETE http://{app-name}-{project-name}.{oso-route-hostname}/api/fruits/1
 --
 
 If you receive an HTTP Error code `503` as a response after executing these commands, it means that the application is not ready yet.

--- a/docs/topics/crud-mission-deploy-booster.adoc
+++ b/docs/topics/crud-mission-deploy-booster.adoc
@@ -8,7 +8,7 @@ include::booster-deploy-openshift-online.adoc[leveloffset=+1]
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 
-. Get your authentication token for using the `oc` CLI client with your {OpenShiftOnline} account. You can find this in the _Command Line Tools_ section your {OpenShiftOnline} Web console. 
+. Get your authentication token for using the `oc` CLI client with your {OpenShiftOnline} account. You can find this in the _Command Line Tools_ section your {OpenShiftOnline} Web console.
 
 . Authenticate your `oc` CLI client with your {OpenShiftOnline} account by using your authentication token.
 +
@@ -73,9 +73,9 @@ Your `{app-name}` pod should have a status of `Running` and should be indicated 
 ----
 $ oc get routes
 NAME                 HOST/PORT                                     PATH      SERVICES             PORT      TERMINATION
-{app-name}   {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com      {app-name}   8080
+{app-name}   {app-name}-{project-name}.{oso-route-hostname}      {app-name}   8080
 ----
 +
-A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com` as the base URL to access the application.
+A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.{oso-route-hostname}` as the base URL to access the application.
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]

--- a/docs/topics/getting-started-launchpad-update-booster-manual.adoc
+++ b/docs/topics/getting-started-launchpad-update-booster-manual.adoc
@@ -39,7 +39,7 @@ $ oc login {link-osl-auth} --token=$MYTOKEN
 $ oc project {project-name}
 ----
 +
-NOTE: You can find your token in your {OpenShiftLocal} Web console. For example, if your {link-osl-auth} is `https://192.168.99.100:8443`, your token would be located at `https://192.168.99.100:8443/console/command-line`. 
+NOTE: You can find your token in your {OpenShiftLocal} Web console. For example, if your {link-osl-auth} is `https://{osl-login-url}`, your token would be located at `https://{osl-login-url}/console/command-line`. 
 
 . Use maven to start the deployment to your {OpenShiftLocal}.
 +

--- a/docs/topics/getting-started-push-changes-osl.adoc
+++ b/docs/topics/getting-started-push-changes-osl.adoc
@@ -56,7 +56,7 @@ In the above example, `wfswarm-rest-http-1-123ab` is the main pod.
 ----
 $ oc get route wfswarm-rest-http
 NAME                HOST/PORT                                              PATH      SERVICES            PORT      TERMINATION   WILDCARD
-wfswarm-rest-http   wfswarm-rest-http-my-wfs-booster.192.168.64.2.nip.io             wfswarm-rest-http   8080                    None
+wfswarm-rest-http   wfswarm-rest-http-my-wfs-booster.{osl-route-hostname}             wfswarm-rest-http   8080                    None
 ----
 
 . Interact with your booster.
@@ -65,9 +65,9 @@ Use `curl` to execute a `GET` request against the booster.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl wfswarm-rest-http-my-wfs-booster.192.168.64.2.nip.io/api/greeting
+$ curl wfswarm-rest-http-my-wfs-booster.{osl-route-hostname}/api/greeting
 {"content":"Hi there, World!"}
-$ curl wfswarm-rest-http-my-wfs-booster.192.168.64.2.nip.io/api/greeting?name=Sarah
+$ curl wfswarm-rest-http-my-wfs-booster.{osl-route-hostname}/api/greeting?name=Sarah
 {"content":"Hi there, Sarah!"}
 ----
 

--- a/docs/topics/getting-started-push-changes-oso.adoc
+++ b/docs/topics/getting-started-push-changes-oso.adoc
@@ -58,7 +58,7 @@ In the above example, `wfswarm-rest-http-1-123ab` is the main pod
 ----
 $ oc get route wfswarm-rest-http
 NAME                HOST/PORT                                              PATH      SERVICES            PORT      TERMINATION   WILDCARD
-wfswarm-rest-http   wfswarm-rest-http-my-oso-wfs-booster.1ab5.starter-us-east-1.openshiftapps.com  
+wfswarm-rest-http   wfswarm-rest-http-my-oso-wfs-booster.{oso-route-hostname}  
            wfswarm-rest-http   8080                    None
 ----
 
@@ -68,8 +68,8 @@ Use `curl` to execute a `GET` request against the booster.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl wfswarm-rest-http-my-oso-wfs-booster.1ab5.starter-us-east-1.openshiftapps.com/api/greeting/
+$ curl wfswarm-rest-http-my-oso-wfs-booster.{oso-route-hostname}/api/greeting/
 {"content":"Hi there, World!"}
-$ curl wfswarm-rest-http-my-oso-wfs-booster.1ab5.starter-us-east-1.openshiftapps.com/api/greeting?name=Sarah
+$ curl wfswarm-rest-http-my-oso-wfs-booster.{oso-route-hostname}/api/greeting?name=Sarah
 {"content":"Hi there, Sarah!"}
 ----

--- a/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -16,7 +16,7 @@ NOTE: The below steps use the command line to interact with the service. Alterna
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -26,11 +26,11 @@ Invoking the /api/killme endpoint simulates an internal service failure and trig
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/killme
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/killme
 
 (followed by)
 
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 
 <html>
   <head><title>Error</title></head>
@@ -57,7 +57,7 @@ Alternatively to the interaction using the terminal window, you can use the web 
 +
 [source,bash,option="nowrap",subs="attributes"]
 --
-$ http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
+$ http://{app-name}-{project-name}.{oso-route-hostname}
 --
 
 include::health-check-mission-web-console-log-output.adoc[leveloffset=+1]

--- a/docs/topics/health-check-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-vertx.adoc
@@ -16,7 +16,7 @@ NOTE: The below steps use the command line to interact with the service. Alterna
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -26,12 +26,12 @@ Invoking the `/api/killme` endpoint simulates an internal service failure and tr
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/killme
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/killme
 Stopping HTTP server, Bye bye world !
 
 (followed by)
 
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 Not online
 ----
 
@@ -54,7 +54,7 @@ Alternatively to the interaction using the terminal window, you can use the web 
 +
 [source,bash,option="nowrap",subs="attributes+"]
 --
-http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
+http://{app-name}-{project-name}.{oso-route-hostname}
 --
 
 include::health-check-mission-web-console-log-output.adoc[leveloffset=+1]

--- a/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
@@ -8,7 +8,7 @@ In the following we demonstrate the basic interactions on the command line that 
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -16,11 +16,11 @@ $ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/killme
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/killme
 
 (followed by)
 
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 
 <html>
   <head><title>Error</title></head>
@@ -43,7 +43,7 @@ NAME                           READY     STATUS    RESTARTS   AGE
 +
 [source,bash,option="nowrap",subs="attributes"]
 --
-$ http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
+$ http://{app-name}-{project-name}.{oso-route-hostname}
 --
 
 include::health-check-mission-web-console-log-output.adoc[leveloffset=+1]

--- a/docs/topics/health-check-mission-deploy-booster.adoc
+++ b/docs/topics/health-check-mission-deploy-booster.adoc
@@ -56,9 +56,9 @@ Your `health-check` pod should have a status of `Running` once it's fully deploy
 ----
 $ oc get routes
 NAME                   HOST/PORT                                            PATH      SERVICES               PORT      TERMINATION   WILDCARD
-{app-name}   {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com           {app-name}   8080                    None
+{app-name}   {app-name}-{project-name}.{oso-route-hostname}           {app-name}   8080                    None
 ----
 +
-A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com` as the base URL to access the applications.
+A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.{oso-route-hostname}` as the base URL to access the applications.
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]

--- a/docs/topics/minishift-install-create-launchpad-app.adoc
+++ b/docs/topics/minishift-install-create-launchpad-app.adoc
@@ -25,14 +25,14 @@ image::minishift_processtemplate.png[Process Template]
 . Fill out the following fields.
 ** _Your GitHub username_.
 ** _Your GitHub Mission Control access token_ is your personal access token for GitHub.
-** The _Target OpenShift Console URL_ is the OpenShift Console URL from your {OpenShiftLocal}. This should be the same base URL you are currently using to complete the form, for example `https://192.168.42.152:8443`.
+** The _Target OpenShift Console URL_ is the OpenShift Console URL from your {OpenShiftLocal}. This should be the same base URL you are currently using to complete the form, for example `+++https://192.168.42.152:8443+++`.
 ** OpenShift username and password from your {OpenShiftLocal}, for example `developer` for the username and password.
 ** _KeyCloak URL_ and _KeyCloak Realm_ **MUST** be cleared out.
 +
 WARNING: You must clear these fields out for the {launcher} application on your {OpenShiftLocal} to be configured correctly.
 
 ** _Catalog Git Repository_ and _Catalog Git Reference_ should be generally left as-is, unless you are developing against a specific fork you would like to use.
-** _{launcher} Frontend Host_ must be entered. Usually this takes the form of `launchpad-frontend-$PROJECTNAME.$HOSTNAMEORIP.nip.io`, replacing `$PROJECTNAME` with the name of your project and `$HOSTNAMEORIP` with the IP address of your OpenShift Console URL. This example uses `my-launcher` and `+++192.168.42.152+++` to make `launchpad-frontend-my-launcher.192.168.42.152.nip.io`.
+** _{launcher} Frontend Host_ must be entered. Usually this takes the form of `launchpad-frontend-$PROJECTNAME.$HOSTNAMEORIP.nip.io`, replacing `$PROJECTNAME` with the name of your project and `$HOSTNAMEORIP` with the IP address of your OpenShift Console URL. This example uses `my-launcher` and `+++192.168.42.152+++` to make `+++launchpad-frontend-my-launcher.192.168.42.152.nip.io+++`.
 
 . Before proceeding to the next steps, confirm all the fields are correct. Also confirm that _KeyCloak URL_ and _KeyCloak Realm_ **have been cleared out**.
 

--- a/docs/topics/minishift-install-nexus-setup.adoc
+++ b/docs/topics/minishift-install-nexus-setup.adoc
@@ -1,3 +1,4 @@
+// name variable defined locally, because it is only used in this topic
 :nexus-project-name: NEXUS_PROJECT_NAME
 
 = Using a Nexus Repository Server With the {launcher} Application on your {OpenShiftLocal}
@@ -49,7 +50,7 @@ You also need to use version 3.6.0-alpha.1 or later of the `oc` CLI tool.
 +
 [source,bash,subs="attributes+"]
 --
-oc login https://192.168.42.10:8443 -u developer -p developer
+oc login https://{osl-login-url} -u developer -p developer
 --
 +
 . You can reuse the Docker daemon instance used by {OpenShiftLocal} to download the latest versions of the Nexus Docker container image.
@@ -104,7 +105,7 @@ oc get routes
 [source,bash,subs="attributes+"]
 ----
 NAME      HOST/PORT                              PATH      SERVICES   PORT       TERMINATION
-nexus     nexus-{nexus-project-name}.192.168.42.106.nip.io             nexus      8080:8080
+nexus     nexus-{nexus-project-name}.{osl-route-hostname}             nexus      8080:8080
 ----
 +
 [NOTE]
@@ -119,7 +120,7 @@ Nexus comes pre-configured for the Maven Central Repository, but you may need ot
 oc project {project-name}
 --
 +
-. Assign the `admin` role to your Jenkins instance and the `edit` permissions to your OpenShift account.
+. Assign the `admin` role to your Jenkins application and the `edit` permissions to your OpenShift account.
 Skip this step if you have already assigned these permissions.
 +
 [source,bash,subs="attributes+"]
@@ -138,16 +139,16 @@ oc get routes jenkins
 [source,bash,subs="attributes+"]
 --
 NAME      HOST/PORT                                         PATH      SERVICES   PORT      TERMINATION
-jenkins   jenkins-{app-name}-{project-name}.192.168.42.106.nip.io             jenkins    <all>     edge/Redirect
+jenkins   jenkins-{app-name}-{project-name}.{osl-route-hostname}             jenkins    <all>     edge/Redirect
 --
 +
-. Navigate to `jenkins-{app-name}-{project-name}.192.168.42.106.nip.io/configure`, and log in using your OpenShift credentials to access the Jenkins configuration page.
+. Navigate to `jenkins-{app-name}-{project-name}.{osl-route-hostname}/configure`, and log in using your OpenShift credentials to access the Jenkins configuration page.
 +
-. In the section titled _Kubernetes Pod Template_,  click on  on _Add Evironmental Variable_ and choose the _Global Environmental Variable_ option from the drop-down menu.
+. Go to the section titled _Kubernetes Pod Template_,  click on _Add Evironmental Variable_, and select _Global Environmental Variable_ option from the drop-down menu.
 +
-. Define a new environment variable with the following properties:
+. Define a new environment variable:
 * Name: `MAVEN_MIRROR_URL`
-* Value: `nexus-{nexus-project-name}.192.168.42.106.nip.io/nexus/content/groups/public/`
+* Value: `nexus-{nexus-project-name}.{osl-route-hostname}/nexus/content/groups/public/`
 +
 [NOTE]
 --
@@ -171,5 +172,3 @@ KNOWN ISSUE: Redeploying your instance of Jenkins server causes other ongoing bu
 --
 +
 .  Navigate to the project that contains your Booster and use the Web console to go to _Builds_ > _Pipelines_ and click _Start Pipeline_ to rebuild your Booster application.
-+
-Your Jenkins instance is now configured to use the Nexus server as a proxy for retrieving artifacts form the Maven Central Repository when a pipeline build is triggered.

--- a/docs/topics/minishift-install-start-configure-minishift.adoc
+++ b/docs/topics/minishift-install-start-configure-minishift.adoc
@@ -30,7 +30,7 @@ Your {OpenShiftLocal}, by default, will select a virtual machine driver. Dependi
 Depending on your operating system, virtual machine driver, and the number of boosters you run, you may need to increase the amount memory you give you to your {OpenShiftLocal}.
 ====
 +
-You now have OpenShift running in a single-node cluster on your local machine. The log information provided by your {OpenShiftLocal} provides the address you need to use to access the web console as well as the credentials to log in. In the above example, the console is located at `https://192.168.42.152:8443`, the username is `developer` and the password is `developer`.
+You now have OpenShift running in a single-node cluster on your local machine. The log information provided by your {OpenShiftLocal} provides the address you need to use to access the web console as well as the credentials to log in. In the above example, the console is located at `+++https://192.168.42.152:8443+++`, the username is `developer` and the password is `developer`.
 
 . Open the web console using a web browser and authenticate.
 +

--- a/docs/topics/mission-deploy-booster.adoc
+++ b/docs/topics/mission-deploy-booster.adoc
@@ -32,5 +32,5 @@ Once your booster is deployed and started, you can check its route information f
 ----
 $ oc get routes
 NAME                 HOST/PORT                                         PATH      SERVICES             PORT      TERMINATION
-{app-name}           {app-name}-{project-name}.192.168.99.100.nip.io        {app-name}                     8080
+{app-name}           {app-name}-{project-name}.{osl-route-hostname}        {app-name}                     8080
 ----

--- a/docs/topics/mission-secured-deploy-rhsso-zip.adoc
+++ b/docs/topics/mission-secured-deploy-rhsso-zip.adoc
@@ -2,7 +2,7 @@
 = Deploy RH SSO to your {OpenShiftLocal} Manually
 
 :sso-app-name: secure-sso
-:sso-auth-url: https://{sso-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/auth
+:sso-auth-url: https://{sso-app-name}-MY_PROJECT_NAME.{osl-route-hostname}/auth
 
 == Download the Secured Booster ZIP File from your {launcher} Application
 

--- a/docs/topics/readme/circuit-breaker-README.adoc
+++ b/docs/topics/readme/circuit-breaker-README.adoc
@@ -31,11 +31,11 @@ To interact with your booster while it's running on a Single-node Openshift Clus
 ----
 $ oc get route ${greeting-app-name} -o jsonpath={$.spec.host}
 
-${greeting-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io
+${greeting-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 
 $ oc get route ${name-app-name} -o jsonpath={$.spec.host}
 
-${name-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io
+${name-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 
@@ -44,17 +44,17 @@ You can use the form at your application's url or you can use the `curl` command
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://${greeting-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting
+$ curl http://${greeting-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello, World!"}
 
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://${name-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://${name-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/state
 
-$ curl http://${greeting-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting
+$ curl http://${greeting-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello, Fallback!"}
 
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://${name-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://${name-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/state
 
-$ curl http://${greeting-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting
+$ curl http://${greeting-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello, World!"}
 ----
 

--- a/docs/topics/readme/configmap-README.adoc
+++ b/docs/topics/readme/configmap-README.adoc
@@ -73,7 +73,7 @@ To interact with your booster while it's running on a Single-node Openshift Clus
 ----
 $ oc get route ${app-name} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io
+${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 
@@ -81,10 +81,10 @@ You can use the form at your application's url or you can use the `curl` command
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting
+$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting?name=Sarah
+$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
 {"content":"Hello Sarah from a ConfigMap!"}
 ----
 

--- a/docs/topics/readme/crud-README.adoc
+++ b/docs/topics/readme/crud-README.adoc
@@ -15,7 +15,7 @@ $ oc new-project MY_PROJECT_NAME
 
 $ oc new-app -e POSTGRESQL_USER=luke -ePOSTGRESQL_PASSWORD=secret -ePOSTGRESQL_DATABASE=my_data openshift/postgresql-92-centos7 --name=my-database
 
-# Wait for `my-database` application to be running. 
+# Wait for `my-database` application to be running.
 
 $ ${OSORunCMD}
 ----
@@ -28,7 +28,7 @@ To interact with your booster while it's running on a Single-node Openshift Clus
 ----
 $ oc get route MY_APP_NAME -o jsonpath={$.spec.host}
 
-MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io
+MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 
@@ -37,7 +37,7 @@ You can use the form at your application's url or you can use the `curl` command
 .List all entries in the database
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits
+$ curl http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/fruits
 
 [ {
   "id" : 1,
@@ -54,7 +54,7 @@ $ curl http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits
 .Retrieve an entry with a specific ID
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits/3
+curl http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/fruits/3
 
 {
   "id" : 3,
@@ -66,7 +66,7 @@ curl http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits/3
 .Create a new entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits
+curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/fruits
 
 {
   "id" : 4,
@@ -78,7 +78,7 @@ curl -H "Content-Type: application/json" -X POST -d '{"name":"apple"}'  http://M
 .Update an Entry
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits/1
+curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/fruits/1
 
 {
   "id" : 1,
@@ -90,7 +90,7 @@ curl -H "Content-Type: application/json" -X PUT -d '{"name":"pineapple"}'  http:
 .Delete an Entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -X DELETE http://MY_APP_NAME-MY_PROJECT_NAME.192.168.42.158.nip.io/api/fruits/1
+curl -X DELETE http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/fruits/1
 ----
 
 NOTE: If you receive an HTTP Error code `503` as a response after executing these commands, it means that the application is not ready yet.

--- a/docs/topics/readme/health-check-README.adoc
+++ b/docs/topics/readme/health-check-README.adoc
@@ -51,7 +51,7 @@ To interact with your booster while it's running on a Single-node Openshift Clus
 ----
 $ oc get route ${app-name} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io
+${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 
@@ -59,13 +59,13 @@ You can use the form at your application's url or you can use the `curl` command
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting
+$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/greeting?name=Sarah
+$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
 {"content":"Hello Sarah from a ConfigMap!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io/api/killme
+$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/killme
 
 $ oc get pods -w
 NAME                           READY     STATUS    RESTARTS   AGE

--- a/docs/topics/readme/rest-http-secured-README.adoc
+++ b/docs/topics/readme/rest-http-secured-README.adoc
@@ -52,7 +52,7 @@ Available application endpoint names: [${secured-app-name}]
 
 $ oc get route ${secured-app-name} -o jsonpath={$.spec.host}
 
-${secured-app-name}-MY_PROJECT_NAME.192.168.42.158.nip.io
+${secured-app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-nodejs.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-nodejs.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -14,7 +14,7 @@ $ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting?name=Sarah
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -14,7 +14,7 @@ $ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting?name=Sarah
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-vertx.adoc
@@ -7,7 +7,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {
   "content" : "Hello, World!"
 }
@@ -17,7 +17,7 @@ $ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting?name=Sarah
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting?name=Sarah
 {
   "content" : "Hello, Sarah!"
 }

--- a/docs/topics/rest-level-0-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-wf-swarm.adoc
@@ -6,7 +6,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -14,7 +14,7 @@ $ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com/api/greeting?name=Sarah
+$ curl http://{app-name}-{project-name}.{oso-route-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/rest-level-0-mission-deploy-booster.adoc
+++ b/docs/topics/rest-level-0-mission-deploy-booster.adoc
@@ -67,10 +67,10 @@ You `app1` pod should have a status of `Running` once its fully deployed and sta
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}         {app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com      {app-name}      8080
+{app-name}         {app-name}-{project-name}.{oso-route-hostname}      {app-name}      8080
 ----
 +
-A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com` as the base URL to access the application.
+A pod's route information gives you the base URL which you use to access it. In the example above, you would use `http://{app-name}-{project-name}.{oso-route-hostname}` as the base URL to access the application.
 
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]

--- a/docs/topics/rest-level-0-mission-form-note.adoc
+++ b/docs/topics/rest-level-0-mission-form-note.adoc
@@ -1,1 +1,1 @@
-NOTE: You can also use a form provided by the booster to perform these same interactions. The form is located at the root of the project `http://{app-name}-{project-name}.1ab5.starter-us-east-1.openshiftapps.com`.
+NOTE: You can also use a form provided by the booster to perform these same interactions. The form is located at the root of the project `http://{app-name}-{project-name}.{oso-route-hostname}`.

--- a/docs/topics/secured-mission-intro.adoc
+++ b/docs/topics/secured-mission-intro.adoc
@@ -27,7 +27,7 @@ The `alice` user has a password of `password` and is the canonical application. 
   "exp": 1489698336,
   "nbf": 0,
   "iat": 1489698276,
-  "iss": "https://secure-sso-sso.192.168.99.100.nip.io/auth/realms/master", <1>
+  "iss": "https://secure-sso-sso.{osl-route-hostname}/auth/realms/master", <1>
   "aud": "demoapp",
   "sub": "c0175ccb-0892-4b31-829f-dda873815fe8",
   "typ": "Bearer",

--- a/docs/topics/secured-mission-sb-interaction.adoc
+++ b/docs/topics/secured-mission-sb-interaction.adoc
@@ -4,9 +4,9 @@
 [cols="3,6,1,2,1,2"]
 |===
 NAME,HOST/PORT,PATH,SERVICES,PORT,TERMINATION
-secure-sso,secure-sso-myproject.192.168.99.100.nip.io,,secure-sso,<all>,passthrough
-secured-springboot-rest,secured-springboot-rest-myproject.192.168.99.100.nip.io,,secured-springboot-rest,<all>,
-sso,sso-myproject.192.168.99.100.nip.io,,sso,<all>,
+secure-sso,secure-sso-myproject.{osl-route-hostname},,secure-sso,<all>,passthrough
+secured-springboot-rest,secured-springboot-rest-myproject.{osl-route-hostname},,secured-springboot-rest,<all>,
+sso,sso-myproject.{osl-route-hostname},,sso,<all>,
 |===
 
 Alternatively, obtain the Secured booster endpoint name using the Java client:
@@ -16,7 +16,7 @@ Alternatively, obtain the Secured booster endpoint name using the Java client:
 $ cd sso
 $ java -jar target/sso-client.jar --displaySSOURL
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest] <1>
 ----
 <1> The line beginning with `Available application endpoint names:` shows the non-SSO related application names. In this case, it is `secured-springboot-rest`.
@@ -26,7 +26,7 @@ Obtain the access token in JSON format and use the `jq` CLI tool to extract the 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
+MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
 ----
 
 = Example Client Output
@@ -36,7 +36,7 @@ MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.n
 ----
 $ java -jar target/sso-client.jar --app secured-springboot-rest
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest]
 
 Requesting greeting...
@@ -50,7 +50,7 @@ Alternatively, make a request against the `/greeting` endpoint using your token 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -k -v http://secured-springboot-rest-{project-name}-latest.192.168.99.100.nip.io/greeting -H "Authorization:Bearer $MY_TOKEN"
+curl -k -v http://secured-springboot-rest-{project-name}-latest.{osl-route-hostname}/greeting -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 
@@ -59,7 +59,7 @@ curl -k -v http://secured-springboot-rest-{project-name}-latest.192.168.99.100.n
 ----
 $ java -jar target/sso-client.jar --app secured-springboot-rest --from Scott
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest]
 
 Requesting greeting...
@@ -73,7 +73,7 @@ Alternatively, make a request against the `/greeting` endpoint passing a custom 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -kv http://secured-springbot-rest-{project-name}.192.168.99.100.nip.io/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
+curl -kv http://secured-springbot-rest-{project-name}.{osl-route-hostname}/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 
@@ -82,7 +82,7 @@ curl -kv http://secured-springbot-rest-{project-name}.192.168.99.100.nip.io/gree
 ----
 $ java -jar target/sso-client.jar --app secured-springboot-rest --password bad
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest]
 Exception in thread "main" java.lang.RuntimeException: Failed to request token
 	at client.authz.AuthzClient.obtainAccessToken(AuthzClient.java:70)
@@ -102,7 +102,7 @@ Caused by: javax.ws.rs.NotAuthorizedException: HTTP 401 Unauthorized
 ----
 $ java -jar target/sso-client.jar --app secured-springboot-rest --user admin --password admin
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest]
 
 Requesting greeting...
@@ -122,9 +122,9 @@ Exception in thread "main" javax.ws.rs.ForbiddenException: HTTP 403 Forbidden
 ----
 $ java -jar target/sso-client.jar --app secured-springboot-rest --user admin --password admin --debug 2
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-springboot-rest]
-Sending POST to: https://secure-sso-myproject.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token
+Sending POST to: https://secure-sso-myproject.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token
 Headers:
   Accept: application/json
   Content-Type: application/x-www-form-urlencoded
@@ -134,7 +134,7 @@ Body: grant_type=password&username=admin&password=admin&client_id=demoapp&client
 Token: eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MDcwYWY5NC03NWU0LTQxMzItYThlNi1mYmQ4N2NhMWNhNDIiLCJleHAiOjE0OTI2MzM2NzMsIm5iZiI6MCwiaWF0IjoxNDkyNjMzNjEzLCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIwNDRkMzcyZS1lZWUyLTRlOGQtOWJiNC05ZDYwYjZmODBlMmUiLCJjbGllbnRfc2Vzc2lvbiI6IjI5NTQ0ZjMwLTZlNWYtNGI1ZS1iZmIzLTc0YTI2NmQyZjVlZCIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.iiS6mGu9OYchCzshl4RQ5inXq4eRjqv_I6FmwQAySk7DIBqzKgx4RTT95oVRfRiQWXU4r6CNLSvJ5ynUUQ6pIRif16AYKWZcmiUjELRPr-xJObr3PhvjhJBGlyKVG6WwYHNGR9wXKDJXakSXROs-f0xkFr16UcjWg7GMSs_MqBs71qC5MdKj--ma7kRgnvvnlJ7V-H2SISlLqOsJbDJcA6QEYQELYIpR059civk7D9kkQLEB0rMmtRXaL_1Aq0srkMxFWJ2aI9XxFN6WyR8tTyW0_ncAXqG5rq273js5a8ONunJE4abpvJn-CMBzU3RIxpEN-D__AXCEeH8vw3uDbw
 
 Requesting greeting...
-Sending GET to: http://secured-springboot-rest-myproject.192.168.99.100.nip.io/greeting?name=World
+Sending GET to: http://secured-springboot-rest-myproject.{osl-route-hostname}/greeting?name=World
 Headers:
   Accept: application/json
   Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MDcwYWY5NC03NWU0LTQxMzItYThlNi1mYmQ4N2NhMWNhNDIiLCJleHAiOjE0OTI2MzM2NzMsIm5iZiI6MCwiaWF0IjoxNDkyNjMzNjEzLCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIwNDRkMzcyZS1lZWUyLTRlOGQtOWJiNC05ZDYwYjZmODBlMmUiLCJjbGllbnRfc2Vzc2lvbiI6IjI5NTQ0ZjMwLTZlNWYtNGI1ZS1iZmIzLTc0YTI2NmQyZjVlZCIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.iiS6mGu9OYchCzshl4RQ5inXq4eRjqv_I6FmwQAySk7DIBqzKgx4RTT95oVRfRiQWXU4r6CNLSvJ5ynUUQ6pIRif16AYKWZcmiUjELRPr-xJObr3PhvjhJBGlyKVG6WwYHNGR9wXKDJXakSXROs-f0xkFr16UcjWg7GMSs_MqBs71qC5MdKj--ma7kRgnvvnlJ7V-H2SISlLqOsJbDJcA6QEYQELYIpR059civk7D9kkQLEB0rMmtRXaL_1Aq0srkMxFWJ2aI9XxFN6WyR8tTyW0_ncAXqG5rq273js5a8ONunJE4abpvJn-CMBzU3RIxpEN-D__AXCEeH8vw3uDbw

--- a/docs/topics/secured-mission-vx-interaction.adoc
+++ b/docs/topics/secured-mission-vx-interaction.adoc
@@ -4,9 +4,9 @@
 [cols="3,6,1,2,1,2"]
 |===
 NAME,HOST/PORT,PATH,SERVICES,PORT,TERMINATION
-secure-sso,secure-sso-myproject.192.168.99.100.nip.io,,secure-sso,<all>,passthrough
-secured-vertx-http,secured-vertx-http-myproject.192.168.99.100.nip.io,,secured-vertx-http,<all>,
-sso,sso-myproject.192.168.99.100.nip.io,,sso,<all>,
+secure-sso,secure-sso-myproject.{osl-route-hostname},,secure-sso,<all>,passthrough
+secured-vertx-http,secured-vertx-http-myproject.{osl-route-hostname},,secured-vertx-http,<all>,
+sso,sso-myproject.{osl-route-hostname},,sso,<all>,
 |===
 
 Alternatively, obtain the Secured booster endpoint name using the Java client:
@@ -16,7 +16,7 @@ Alternatively, obtain the Secured booster endpoint name using the Java client:
 $ cd sso
 $ java -jar target/sso-client.jar --displaySSOURL
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http] <1>
 ----
 <1> The line beginning with `Available application endpoint names:` shows the non-SSO related application names.
@@ -27,7 +27,7 @@ Obtain the access token in JSON format and use the `jq` CLI tool to extract the 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
+MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
 ----
 
 = Example Client Output
@@ -37,7 +37,7 @@ MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.n
 ----
 $ java -jar target/sso-client.jar --app secured-vertx-http
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http]
 
 Requesting greeting...
@@ -51,7 +51,7 @@ Alternatively, make a request against the `/greeting` endpoint using your token 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -k -v http://secured-vertx-http-{project-name}-latest.192.168.99.100.nip.io/greeting -H "Authorization:Bearer $MY_TOKEN"
+curl -k -v http://secured-vertx-http-{project-name}-latest.{osl-route-hostname}/greeting -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 .Authentication with Default User Using `--from` Parameter
@@ -59,7 +59,7 @@ curl -k -v http://secured-vertx-http-{project-name}-latest.192.168.99.100.nip.io
 ----
 $ java -jar target/sso-client.jar --app secured-vertx-http --from Scott
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http]
 
 Requesting greeting...
@@ -73,7 +73,7 @@ Alternatively, make a request against the `/greeting` endpoint passing a custom 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -kv http://secured-vertx-http-{project-name}.192.168.99.100.nip.io/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
+curl -kv http://secured-vertx-http-{project-name}.{osl-route-hostname}/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 
@@ -82,7 +82,7 @@ curl -kv http://secured-vertx-http-{project-name}.192.168.99.100.nip.io/greeting
 ----
 $ java -jar target/sso-client.jar --app secured-vertx-http --password bad
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http]
 Exception in thread "main" java.lang.RuntimeException: Failed to request token
 	at client.authz.AuthzClient.obtainAccessToken(AuthzClient.java:70)
@@ -102,7 +102,7 @@ Caused by: javax.ws.rs.NotAuthorizedException: HTTP 401 Unauthorized
 ----
 $ java -jar target/sso-client.jar --app secured-vertx-http --user admin --password admin
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http]
 
 Requesting greeting...
@@ -122,9 +122,9 @@ Exception in thread "main" javax.ws.rs.ForbiddenException: HTTP 403 Forbidden
 ----
 $ java -jar target/sso-client.jar --app secured-vertx-http --user admin --password admin --debug 2
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [secured-vertx-http]
-Sending POST to: https://secure-sso-myproject.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token
+Sending POST to: https://secure-sso-myproject.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token
 Headers:
   Accept: application/json
   Content-Type: application/x-www-form-urlencoded
@@ -134,7 +134,7 @@ Body: grant_type=password&username=admin&password=admin&client_id=demoapp&client
 Token: eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJlNjRhNDg5NC1iMTgxLTQ2NDYtYWIxNC02ZDQxNWE0NzM3NDkiLCJleHAiOjE0OTI2MzMxODQsIm5iZiI6MCwiaWF0IjoxNDkyNjMzMTI0LCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIxNjA0NGEyYS0wYTQ2LTQ1MDMtYTg3OC0wNThhNzE0ZjExM2YiLCJjbGllbnRfc2Vzc2lvbiI6ImU0MTQ3OTM1LWY3N2UtNDU2OC04YzJmLTc5MzNlM2I4NGM0NSIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.eE-DxBfuhBg8ob17GlywIxh33owCUfbJGipXhV4R1Z14eE0yVXIe62lAHRrqygE5MFIGZ11UyKf4SwVl6YJHzDtVVbUMZQL4KFZ_ZUbUW7k16e0THlKtrBqvbJerTmeNocGOqh0vqNbi3PFVcmhihxPAO8iDxNI03t5J3_hkebIxVU4ka9XVrICXyrJmCDNjwmIeodoPTebIF7hZMAZub0W-Hyho65jWqlMcSxUg10FPe7wKkT0oP40DMN8yytKUIJTbd1EPm-qj354I2ztVing4ElecbdddjOAgL6a2fybZrDm0mtkcU5fV17gTwQubKB4hnXntSxO4pKNMy-tVpw
 
 Requesting greeting...
-Sending GET to: http://secured-vertx-http-myproject.192.168.99.100.nip.io/greeting?name=World
+Sending GET to: http://secured-vertx-http-myproject.{osl-route-hostname}/greeting?name=World
 Headers:
   Accept: application/json
   Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJlNjRhNDg5NC1iMTgxLTQ2NDYtYWIxNC02ZDQxNWE0NzM3NDkiLCJleHAiOjE0OTI2MzMxODQsIm5iZiI6MCwiaWF0IjoxNDkyNjMzMTI0LCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIxNjA0NGEyYS0wYTQ2LTQ1MDMtYTg3OC0wNThhNzE0ZjExM2YiLCJjbGllbnRfc2Vzc2lvbiI6ImU0MTQ3OTM1LWY3N2UtNDU2OC04YzJmLTc5MzNlM2I4NGM0NSIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.eE-DxBfuhBg8ob17GlywIxh33owCUfbJGipXhV4R1Z14eE0yVXIe62lAHRrqygE5MFIGZ11UyKf4SwVl6YJHzDtVVbUMZQL4KFZ_ZUbUW7k16e0THlKtrBqvbJerTmeNocGOqh0vqNbi3PFVcmhihxPAO8iDxNI03t5J3_hkebIxVU4ka9XVrICXyrJmCDNjwmIeodoPTebIF7hZMAZub0W-Hyho65jWqlMcSxUg10FPe7wKkT0oP40DMN8yytKUIJTbd1EPm-qj354I2ztVing4ElecbdddjOAgL6a2fybZrDm0mtkcU5fV17gTwQubKB4hnXntSxO4pKNMy-tVpw

--- a/docs/topics/secured-mission-wf-interaction.adoc
+++ b/docs/topics/secured-mission-wf-interaction.adoc
@@ -4,9 +4,9 @@
 [cols="3,6,1,2,1,2"]
 |===
 NAME,HOST/PORT,PATH,SERVICES,PORT,TERMINATION
-secure-sso,secure-sso-myproject.192.168.99.110.nip.io,,secure-sso,<all>,passthrough
-wfswarm-rest-http-secured,wfswarm-rest-http-secured-myproject.192.168.99.110.nip.io,,wfswarm-rest-http-secured,<all>,
-sso,sso-myproject.192.168.99.110.nip.io,,sso,<all>,
+secure-sso,secure-sso-myproject.{osl-route-hostname},,secure-sso,<all>,passthrough
+wfswarm-rest-http-secured,wfswarm-rest-http-secured-myproject.{osl-route-hostname},,wfswarm-rest-http-secured,<all>,
+sso,sso-myproject.{osl-route-hostname},,sso,<all>,
 |===
 
 Alternatively, obtain the Secured booster endpoint name using the Java client:
@@ -16,7 +16,7 @@ Alternatively, obtain the Secured booster endpoint name using the Java client:
 $ cd sso
 $ java -jar target/sso-client.jar --displaySSOURL
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.110.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [wfswarm-rest-http-secured] <1>
 ----
 <1> The line beginning with `Available application endpoint names:` shows the non-SSO related application names.
@@ -27,7 +27,7 @@ Obtain the access token in JSON format and use the `jq` CLI tool to extract the 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
+MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token -d client_id=demoapp -d client_secret=1daa57a2-b60e-468b-a3ac-25bd2dc2eadc -d grant_type=password -d username=alice -d password=password | jq -r .access_token)
 ----
 
 = Example Client Output
@@ -37,7 +37,7 @@ MY_TOKEN=$(curl -s -k -X POST https://secure-sso-{project-name}.192.168.99.100.n
 ----
 $ java -jar target/sso-client.jar --app wfswarm-rest-http-secured
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-sso.e8ca.engint.openshiftapps.com
+Using auth server URL: https://secure-sso-sso.{oso-route-hostname}
 Available application endpoint names: [secured-vertx-rest, wfswarm-rest-http-secured, secured-springboot-rest]
 
 Requesting greeting...
@@ -52,7 +52,7 @@ Alternatively, make a request against the `/greeting` endpoint using your token 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -k -v http://wfswarm-rest-http-secured-{project-name}-latest.192.168.99.100.nip.io/greeting -H "Authorization:Bearer $MY_TOKEN"
+curl -k -v http://wfswarm-rest-http-secured-{project-name}-latest.{osl-route-hostname}/greeting -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 .Authentication with Default User Using `--from` Parameter
@@ -60,7 +60,7 @@ curl -k -v http://wfswarm-rest-http-secured-{project-name}-latest.192.168.99.100
 ----
 $ java -jar target/sso-client.jar --app wfswarm-rest-http-secured --from Scott
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.110.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [wfswarm-rest-http-secured]
 
 Requesting greeting...
@@ -75,7 +75,7 @@ Alternatively, make a request against the `/greeting` endpoint passing a custom 
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-curl -kv http://wfswarm-rest-http-secured-{project-name}.192.168.99.100.nip.io/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
+curl -kv http://wfswarm-rest-http-secured-{project-name}.{osl-route-hostname}/greeting?name=Scott -H "Authorization:Bearer $MY_TOKEN"
 ----
 
 .Authentication with Default User Using Invalid Password
@@ -83,7 +83,7 @@ curl -kv http://wfswarm-rest-http-secured-{project-name}.192.168.99.100.nip.io/g
 ----
 $ java -jar target/sso-client.jar --app wfswarm-rest-http-secured --password bad
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-sso.e8ca.engint.openshiftapps.com
+Using auth server URL: https://secure-sso-sso.{oso-route-hostname}
 Available application endpoint names: [secured-vertx-rest, wfswarm-rest-http-secured, secured-springboot-rest]
 Exception in thread "main" java.lang.RuntimeException: Failed to request token
 	at client.authz.AuthzClient.obtainAccessToken(AuthzClient.java:67)
@@ -103,7 +103,7 @@ Caused by: javax.ws.rs.NotAuthorizedException: HTTP 401 Unauthorized
 ----
 $ java -jar target/sso-client.jar --app wfswarm-rest-http-secured --user admin --password admin
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-sso.e8ca.engint.openshiftapps.com
+Using auth server URL: https://secure-sso-sso.{oso-route-hostname}
 Available application endpoint names: [secured-vertx-rest, wfswarm-rest-http-secured, secured-springboot-rest]
 Exception in thread "main" javax.ws.rs.ForbiddenException: HTTP 403 Forbidden
 	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.handleErrorStatus(ClientInvocation.java:216)
@@ -121,9 +121,9 @@ Exception in thread "main" javax.ws.rs.ForbiddenException: HTTP 403 Forbidden
 ----
 $ java -jar target/sso-client.jar --app wfswarm-rest-http-secured --user admin --password admin --debug 2
 Successful oc get routes: Yes
-Using auth server URL: https://secure-sso-myproject.192.168.99.100.nip.io/auth
+Using auth server URL: https://secure-sso-myproject.{osl-route-hostname}/auth
 Available application endpoint names: [wfswarm-rest-http-secured]
-Sending POST to: https://secure-sso-myproject.192.168.99.100.nip.io/auth/realms/master/protocol/openid-connect/token
+Sending POST to: https://secure-sso-myproject.{osl-route-hostname}/auth/realms/master/protocol/openid-connect/token
 Headers:
   Accept: application/json
   Content-Type: application/x-www-form-urlencoded
@@ -133,7 +133,7 @@ Body: grant_type=password&username=admin&password=admin&client_id=demoapp&client
 Token: eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIwODNiMmUzNi0yMDY0LTQ2OTYtYjZlMS00MGViNmE3ZDhhODgiLCJleHAiOjE0OTI2MzIzMTIsIm5iZiI6MCwiaWF0IjoxNDkyNjMyMjUyLCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIyODE3ZjRkYS04OTVkLTQ2MmMtYjBkNi1mYWI4MjU3ODNhZWMiLCJjbGllbnRfc2Vzc2lvbiI6ImIzZjNmNzQ5LTg0NzItNDE1OC05Y2Y0LWExMzM4M2RlN2FmOSIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.mTlSe7g5f-XvkZgkQb61e5Rr7g85aowcGvzVESEVCp3Hp_tPB244ovVqssrJ97fABa5FxszuJdY3teM9oj-tjUhK5jfUKbwGHrVcdvumRbMv6SJ2TKxA24L9TaDrBqda3GzCUgRCQtu01yyjYeRruXVK9z3YybQic6Zrx2auaAo3PkUZAoe3qcoXcgwlekao4_yXGmZ54U3duOLf_J_dduOdldxrc07DrHh-GQu_xYUWvOYMkj_aGOn2dTYnM-G6Uw_BYshdRW2xUJgDE_a8Ff7iHBDNpROGuC0_7z22J8nYgUO5gnpwTl5BUmo0liSMfxnPY_3Wa_n3413S2qc21g
 
 Requesting greeting...
-Sending GET to: http://wfswarm-rest-http-secured-myproject.192.168.99.100.nip.io/greeting?name=World
+Sending GET to: http://wfswarm-rest-http-secured-myproject.{osl-route-hostname}/greeting?name=World
 Headers:
   Accept: application/json
   Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiIwODNiMmUzNi0yMDY0LTQ2OTYtYjZlMS00MGViNmE3ZDhhODgiLCJleHAiOjE0OTI2MzIzMTIsIm5iZiI6MCwiaWF0IjoxNDkyNjMyMjUyLCJpc3MiOiJodHRwczovL3NlY3VyZS1zc28tbXlwcm9qZWN0LjE5Mi4xNjguOTkuMTAwLm5pcC5pby9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJhdWQiOiJkZW1vYXBwIiwic3ViIjoiMjYyNjc3ZmEtMTAyYi00ZDYwLTlhNjEtYjFjYTJhZmQ2NjNhIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVtb2FwcCIsInNlc3Npb25fc3RhdGUiOiIyODE3ZjRkYS04OTVkLTQ2MmMtYjBkNi1mYWI4MjU3ODNhZWMiLCJjbGllbnRfc2Vzc2lvbiI6ImIzZjNmNzQ5LTg0NzItNDE1OC05Y2Y0LWExMzM4M2RlN2FmOSIsImFsbG93ZWQtb3JpZ2lucyI6W10sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjcmVhdGUtcmVhbG0iLCJhZG1pbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7Im1hc3Rlci1yZWFsbSI6eyJyb2xlcyI6WyJtYW5hZ2UtZXZlbnRzIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJ2aWV3LXJlYWxtIiwibWFuYWdlLXJlYWxtIiwibWFuYWdlLWlkZW50aXR5LXByb3ZpZGVycyIsImltcGVyc29uYXRpb24iLCJ2aWV3LWV2ZW50cyIsImNyZWF0ZS1jbGllbnQiLCJtYW5hZ2UtdXNlcnMiLCJ2aWV3LXVzZXJzIiwidmlldy1jbGllbnRzIiwibWFuYWdlLWNsaWVudHMiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.mTlSe7g5f-XvkZgkQb61e5Rr7g85aowcGvzVESEVCp3Hp_tPB244ovVqssrJ97fABa5FxszuJdY3teM9oj-tjUhK5jfUKbwGHrVcdvumRbMv6SJ2TKxA24L9TaDrBqda3GzCUgRCQtu01yyjYeRruXVK9z3YybQic6Zrx2auaAo3PkUZAoe3qcoXcgwlekao4_yXGmZ54U3duOLf_J_dduOdldxrc07DrHh-GQu_xYUWvOYMkj_aGOn2dTYnM-G6Uw_BYshdRW2xUJgDE_a8Ff7iHBDNpROGuC0_7z22J8nYgUO5gnpwTl5BUmo0liSMfxnPY_3Wa_n3413S2qc21g

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -111,5 +111,13 @@
 :link-launcher-yaml: /latest-launcher-template
 :link-launcher-oso: https://launch.openshift.io/wizard/
 
+// Minishift route URL e.g: 192.168.42.152.nip.io
+:osl-route-hostname: LOCAL_OPENSHIFT_HOSTNAME
+
+// Minishift access URL e.g: 192.168.42.152.:8443
+:osl-login-url: LOCAL_OPENSHIFT_URL:PORT
+
+// OSO hostname e.g: 1ab5.starter-us-east-1.openshiftapps.com
+:oso-route-hostname: OPENSHIFT_ONLINE_HOSTNAME
 
 :link-launcher-install-script: https://raw.githubusercontent.com/openshiftio/appdev-documentation/production/scripts/deploy_launchpad_mission.sh


### PR DESCRIPTION
NOTE about the WIP flag:  I only added it so that we  don't merge this before PR #404. Some of the changes in this PR are dependent on those introduced in PR #404

resolves  #374 

* externalized minishift login URLs
* externalize OSO hostnames
* change externalized hostname values to generic placeholders
* revert url replacement for specific url example

This is a follow-up to issue #330.

UPDATE:
* In mission-specific README.adoc files, explicit placeholder values (e.g., ```LOCAL_OPENSHIFT_HOSTNAME```) are used instead of variables.
* The files used by the Launcher front end contain no instances of the ```{oso-route-hostname}``` and ```{osl-route-hostname}``` variable and therefore have not been affected by the bulk find-and-replace operations.