### PR TITLE
Issue #415: Updated minishift and oc version in Nexus setup guide and Install guide to 1.3.1

### DIFF
--- a/docs/topics/minishift-install-nexus-setup.adoc
+++ b/docs/topics/minishift-install-nexus-setup.adoc
@@ -30,14 +30,15 @@ This helps you speed up your builds and rolling updates and alleviates network l
 --
 minishift delete # Delete the previous instance of {OpenShiftLocal}
 minishift config set memory 4096
-minishift config set openshift-version v3.6.0-alpha.1
+minishift config set openshift-version v3.6.0
 minishift start
 --
 +
 [WARNING]
 --
-The procedure described below works with {Minishift} 1.0.0-rc2 It has not been tested with the CDK.
-You also need to use version 3.6.0-alpha.1 or later of the `oc` CLI tool.
+The procedure described below works with {Minishift} version `1.3.1`.
+It has not been tested for use with CDK.
+You must use `oc` version `3.6.0` or later.
 --
 
 * Deploy the {launcher} application to your {OpenShiftLocal}.

--- a/docs/topics/minishift-install-prereq.adoc
+++ b/docs/topics/minishift-install-prereq.adoc
@@ -11,7 +11,7 @@ The installation steps for {Minishift} are available link:https://docs.openshift
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ minishift version
-minishift v1.1.0
+minishift v1.3.1+f4900b07
 ----
 
 . Determine the command to add the correct version of the `oc` binary to your path and run the command.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -62,7 +62,7 @@
 :wf-swarm-runtime-guide-name: {WildFlySwarm} Runtime Guide
 :nodejs-runtime-guide-name: {NodeJS} Runtime Guide
 
-:MinishiftVersion: 1.1.0
+:MinishiftVersion: 1.3.1
 :CDKVersion: 3.0.0
 
 :link-http-api-level-0-spring-boot-tomcat-booster: https://github.com/snowdrop/rest_springboot-tomcat


### PR DESCRIPTION
resolves #415 

also updated ```oc``` binary for use with Nexus to version ```3.6.0```
