### PR TITLE
Quickfix: Update the value of the MinishiftVersion variable to 1.3.1 in document-attributes.adoc

### DIFF
--- a/docs/topics/minishift-install-prereq.adoc
+++ b/docs/topics/minishift-install-prereq.adoc
@@ -11,7 +11,7 @@ The installation steps for {Minishift} are available link:https://docs.openshift
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ minishift version
-minishift v1.3.1
+minishift v1.3.1+f4900b07
 ----
 
 . Determine the command to add the correct version of the `oc` binary to your path and run the command.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -62,7 +62,7 @@
 :wf-swarm-runtime-guide-name: {WildFlySwarm} Runtime Guide
 :nodejs-runtime-guide-name: {NodeJS} Runtime Guide
 
-:MinishiftVersion: 1.1.0
+:MinishiftVersion: 1.3.1
 :CDKVersion: 3.0.0
 
 :link-http-api-level-0-spring-boot-tomcat-booster: https://github.com/snowdrop/rest_springboot-tomcat


### PR DESCRIPTION
Bumped the version in ```document-attributes.adoc``` to ```1.3.1```
added commit number to the output example for the ```minishift version``` command.