### PR TITLE
Issue #425: Fix runtime guide links in additional resources sections

### DIFF
--- a/docs/topics/circuit-breaker-mission-resources.adoc
+++ b/docs/topics/circuit-breaker-mission-resources.adoc
@@ -1,7 +1,20 @@
 [[circuit_breaker_resources]]
 == Circuit Breaker Resources
 
-Follow the links below for more background information on the design principles behind the Circuit Breaker pattern  
+Follow the links below for more background information on the design principles behind the Circuit Breaker pattern
 
 * link:http://microservices.io/patterns/reliability/circuit-breaker.html[microservices.io: Microservice Patterns: Circuit Breaker]
+
 * link:https://martinfowler.com/bliki/CircuitBreaker.html[Martin Fowler: CircuitBreaker]
+
+ifndef::http-api-spring-boot-tomcat[]
+* link:{link-mission-circuit-breaker-spring-boot-tomcat}[{mission-circuit-breaker-spring-boot-tomcat-guide-name}]
+endif::http-api-spring-boot-tomcat[]
+
+ifndef::http-api-vertx[]
+* link:{link-mission-circuit-breaker-vertx}[{mission-circuit-breaker-vertx-guide-name}]
+endif::http-api-vertx[]
+
+ifndef::http-api-wf-swarm[]
+* link:{link-mission-circuit-breaker-wf-swarm}[{mission-circuit-breaker-wf-swarm-guide-name}]
+endif::http-api-wf-swarm[]

--- a/docs/topics/configmap-mission-resources.adoc
+++ b/docs/topics/configmap-mission-resources.adoc
@@ -19,16 +19,13 @@ ifdef::configmap-wf-swarm[]
 endif::configmap-wf-swarm[]
 
 ifndef::configmap-spring-boot-tomcat[]
-* link:{link-configmap-spring-boot-tomcat-booster}[ConfigMap - {SpringBoot} Booster]
+* link:{link-mission-configmap-spring-boot-tomcat}[ConfigMap - {SpringBoot} Booster]
 endif::configmap-spring-boot-tomcat[]
 
 ifndef::configmap-vertx[]
-* link:{link-configmap-vertx-booster}[ConfigMap - {VertX} Booster]
+* link:{link-mission-configmap-vertx}[ConfigMap - {VertX} Booster]
 endif::configmap-vertx[]
 
 ifndef::configmap-wf-swarm[]
-* link:{link-configmap-wf-swarm-booster}[ConfigMap - {WildFlySwarm} Booster]
+* link:{link-mission-configmap-wf-swarm}[ConfigMap - {WildFlySwarm} Booster]
 endif::configmap-wf-swarm[]
-
-
-

--- a/docs/topics/crud-mission-resources.adoc
+++ b/docs/topics/crud-mission-resources.adoc
@@ -25,13 +25,13 @@ ifdef::http-api-wf-swarm[]
 endif::http-api-wf-swarm[]
 
 ifndef::http-api-spring-boot-tomcat[]
-* link:{link-http-api-level-0-spring-boot-tomcat-booster}[HTTP API Rest Level 0 - {SpringBoot} Booster]
+* link:{link-mission-crud-spring-boot-tomcat}[{mission-crud-spring-boot-tomcat-guide-name}]
 endif::http-api-spring-boot-tomcat[]
 
 ifndef::http-api-vertx[]
-* link:{link-http-api-level-0-vertx-booster}[HTTP API Rest Level 0 - {VertX} Booster]
+* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]
 endif::http-api-vertx[]
 
 ifndef::http-api-wf-swarm[]
-* link:{link-http-api-level-0-wf-swarm-booster}[HTTP API Rest Level 0 - {WildFlySwarm} Booster]
+* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]
 endif::http-api-wf-swarm[]

--- a/docs/topics/health-check-mission-resources.adoc
+++ b/docs/topics/health-check-mission-resources.adoc
@@ -7,3 +7,15 @@ More background and related information on health checking can be found here:
 * link:https://kubernetes.io/docs/user-guide/walkthrough/k8s201/#health-checking[Health Checking in Kubernetes]
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Kubernetes Liveness and Readiness Probes]
 * link:https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe[Kubernetes Probes]
+
+ifndef::http-api-spring-boot-tomcat[]
+* link:{link-mission-health-check-spring-boot-tomcat}[Health Check - {SpringBoot} Booster]
+endif::http-api-spring-boot-tomcat[]
+
+ifndef::http-api-vertx[]
+* link:{link-mission-health-check-vertx}[Health Check - {VertX} Booster]
+endif::http-api-vertx[]
+
+ifndef::http-api-wf-swarm[]
+* link:{link-mission-health-check-wf-swarm}[Health Check - {WildFlySwarm} Booster]
+endif::http-api-wf-swarm[]

--- a/docs/topics/rest-level-0-mission-resources.adoc
+++ b/docs/topics/rest-level-0-mission-resources.adoc
@@ -28,17 +28,17 @@ ifdef::http-api-wf-swarm[]
 endif::http-api-wf-swarm[]
 
 ifndef::http-api-spring-boot-tomcat[]
-* link:{link-http-api-level-0-spring-boot-tomcat-booster}[{mission-http-api-spring-boot-tomcat-guide-name}]
+* link:{link-mission-http-api-spring-boot-tomcat}[{mission-http-api-spring-boot-tomcat-guide-name}]
 endif::http-api-spring-boot-tomcat[]
 
 ifndef::http-api-vertx[]
-* link:{link-http-api-level-0-vertx-booster}[{mission-http-api-vertx-guide-name}]
+* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]
 endif::http-api-vertx[]
 
 ifndef::http-api-wf-swarm[]
-* link:{link-http-api-level-0-wf-swarm-booster}[{mission-http-api-wf-swarm-guide-name}]
+* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]
 endif::http-api-wf-swarm[]
 
 ifndef::http-api-nodejs[]
-  * link:{link-http-api-level-0-nodejs-booster}[{mission-http-api-nodejs-guide-name}]
+  * link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]
 endif::http-api-nodejs[]

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -88,18 +88,21 @@
 :link-mission-crud-spring-boot-tomcat: {link-spring-boot-runtime-guide}#mission-crud-spring-boot-tomcat
 :link-mission-health-check-spring-boot-tomcat: {link-spring-boot-runtime-guide}#mission-health-check-spring-boot-tomcat
 :link-mission-secured-spring-boot: {link-spring-boot-runtime-guide}#mission-secured-spring-boot
+:link-mission-circuit-breaker-spring-boot-tomcat: {link-spring-boot-runtime-guide}#mission-circuit-breaker-spring-boot-tomcat
 
 :link-mission-http-api-vertx: {link-vertx-runtime-guide}#mission-http-api-vertx
 :link-mission-configmap-vertx: {link-vertx-runtime-guide}#mission-configmap-vertx
 :link-mission-crud-vertx: {link-vertx-runtime-guide}#mission-crud-vertx
 :link-mission-health-check-vertx: {link-vertx-runtime-guide}#mission-health-check-vertx
 :link-mission-secured-vertx: {link-vertx-runtime-guide}#mission-secured-vertx
+:link-mission-circuit-breaker-vertx: {link-vertx-runtime-guide}#mission-circuit-breaker-vertx
 
 :link-mission-http-api-wf-swarm: {link-wf-swarm-runtime-guide}#mission-http-api-wf-swarm
 :link-mission-configmap-wf-swarm: {link-wf-swarm-runtime-guide}#mission-configmap-wf-swarm
 :link-mission-crud-wf-swarm: {link-wf-swarm-runtime-guide}#mission-crud-wf-swarm
 :link-mission-health-check-wf-swarm: {link-wf-swarm-runtime-guide}#mission-health-check-wf-swarm
 :link-mission-secured-wf-swarm: {link-wf-swarm-runtime-guide}#mission-secured-wf-swarm
+:link-mission-circuit-breaker-wf-swarm: {link-wf-swarm-runtime-guide}#mission-circuit-breaker-wf-swarm
 
 :link-mission-http-api-nodejs: {link-nodejs-runtime-guide}#mission-http-api-nodejs
 


### PR DESCRIPTION
Fixed the Github repo links. The conditional links now point to their corresponding runtime guide sections.

NOTE: I ended up doing a couple consistency fixes, too:

* Changed the guide names in the links in the CRUD resources topic to variables 
* Created a variable for the circuit breaker guide link in `document-attributes.adoc`
* included the conditional links in the Circuit Breaker resources topic

Resolves #425
 