### PR TITLE
Testing in CICO build script

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -28,6 +28,10 @@ function tag_push() {
 # Exit on error
 set -e
 
+# Run tests
+./scripts/validateGuides.sh
+
+
 if [ -z $CICO_LOCAL ]; then
     [ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT > inherit-env
     [ -f inherit-env ] && . inherit-env

--- a/scripts/validateGuides.sh
+++ b/scripts/validateGuides.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/usr/bin/bash
 
-
+# Builds all books into DocBook 5 XML and validates them using XMLlint.
 failed_builds=""
 failed_validations=""
 exit_status=0
 
+echo Running tests...
 for dir in $(dirname docs/*/master.adoc); do
-    echo -e "\nBuilding $dir"
+    echo -e "Processing $dir"
     pushd $dir >/dev/null
 
     # Check if this book is ignored in the CI builds
@@ -49,6 +50,12 @@ if test -n "$failed_validations"; then
     for validation in $failed_validations; do
         echo " * $validation"
     done
+fi
+
+if (($exit_status)); then
+    echo -e "\nTesting failed."
+else
+    echo -e "\nTesting passed."
 fi
 
 exit $exit_status


### PR DESCRIPTION
Testing is moved from the `buildGuides-CI.sh` script to the `cico_build_deploy.sh` script before the build process, so if any book fails to validate, the process fails.

The `buildGuides.sh` script is deleted becauase it is no longer necessary.

Doesn't have to be included in Aug 14 release.

Resolves #471.