### PR TITLE
Using date instead of Git to set version name

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -2,7 +2,7 @@ node("docsbuilder-maven") {
   checkout scm
   stage("Build Documentation") {
     sh "pwd && ls -l"
-    sh "echo :revnumber: \$(git describe --abbrev=0 --tags) >> ./docs/topics/templates/document-attributes.adoc"
+    sh "echo :revnumber: \$(date '+%Y-%m-%d') >> ./docs/topics/templates/document-attributes.adoc"
     sh "echo :SegmentTrackerToken: \$LAUNCHPAD_TRACKER_SEGMENT_TOKEN >> ./docs/topics/templates/document-attributes.adoc"
     sh "./scripts/buildGuides.sh"
     sh "mkdir -p ci/openshiftio-appdev-docs/src/main/resources/webroot"

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -49,7 +49,7 @@ docker ps -a | grep -q ${BUILDER_CONT} && docker rm ${BUILDER_CONT}
 rm -rf ${TARGET_DIR}/
 
 #BUILD
-echo :revnumber: $(git describe --abbrev=0 --tags) >> ./docs/topics/templates/document-attributes.adoc
+echo :revnumber: $(date '+%Y-%m-%d') >> ./docs/topics/templates/document-attributes.adoc
 docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
 
 mkdir ${TARGET_DIR}/


### PR DESCRIPTION
NOTE: Replacing in `ci/Jenkinsfile` too in case anyone used it for anything (they shouldn't, though, and the file will be deleted in #439).

Resolves #470.