### PR TITLE
Installing Asciidoctor in CI build

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -28,6 +28,13 @@ function tag_push() {
 # Exit on error
 set -e
 
+# Install Asciidoctor if missing - needed for CI
+if ! asciidoctor --version &>/dev/null; then
+    echo Asciidoctor is missing, installing...
+    yum --version &>/dev/null && yum -y install rubygems
+    gem install asciidoctor
+fi
+
 # Run tests
 ./scripts/validateGuides.sh
 


### PR DESCRIPTION
The CI build environment is missing Asciidoctor. Adding the installation thereof.

I have tested this on Fedora (bare metal), CentOS (in Docker), and UNIX (FreeBSD, assuming `gem` is installed).

Resolves #486.