### PR TITLE
Moved testing into the build container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,9 +5,12 @@ MAINTAINER Zach Rhoads (https://github.com/rhoads-zach)
 USER root
 
 # Install asciidoctor
-RUN yum install -y rubygems && \
+RUN yum install -y rubygems libxml2 && \
     gem install asciidoctor && \
     yum clean all
 
 COPY scripts/ scripts/
 COPY docs/ docs/
+
+RUN scripts/validateGuides.sh
+

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -28,17 +28,6 @@ function tag_push() {
 # Exit on error
 set -e
 
-# Install Asciidoctor if missing - needed for CI
-if ! asciidoctor --version &>/dev/null; then
-    echo Asciidoctor is missing, installing...
-    yum --version &>/dev/null && yum -y install rubygems
-    gem install asciidoctor
-fi
-
-# Run tests
-./scripts/validateGuides.sh
-
-
 if [ -z $CICO_LOCAL ]; then
     [ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT > inherit-env
     [ -f inherit-env ] && . inherit-env


### PR DESCRIPTION
Adding `libxml2` just in case it gets removed from the base CentOS image.

I have tested that if there is a change to the sources, rebuilding indeed triggers revalidation (i. e. the Docker image is not cached).

Resolves #490. 