### PR TITLE
Fix for validate_guides.sh on Mac OS

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 GENERATOR_DOCKER_HUB_USERNAME=openshiftioadmin
 REGISTRY_URI="push.registry.devshift.net"

--- a/scripts/add_guide.sh
+++ b/scripts/add_guide.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GUIDE_NAME=$1
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 sed -i "s#\${LAUNCHPAD_TRACKER_SEGMENT_TOKEN}#$LAUNCHPAD_TRACKER_SEGMENT_TOKEN#" /usr/share/nginx/html/docs/*.html
 

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Not tagging if HEAD is already tagged
 if git name-rev --tags --name-only --no-undefined HEAD &>/dev/null; then

--- a/scripts/validate_guides.sh
+++ b/scripts/validate_guides.sh
@@ -6,7 +6,8 @@ failed_validations=""
 exit_status=0
 
 echo Running tests...
-for dir in $(dirname docs/*/master.adoc); do
+for book in docs/*/master.adoc; do
+    dir="$(dirname $book)"
     echo -e "Processing $dir"
     pushd $dir >/dev/null
 

--- a/scripts/validate_guides.sh
+++ b/scripts/validate_guides.sh
@@ -1,9 +1,16 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Builds all books into DocBook 5 XML and validates them using XMLlint.
 failed_builds=""
 failed_validations=""
 exit_status=0
+
+for binary in asciidoctor xmllint; do
+    if ! $binary --version &>/dev/null; then
+        echo The "$binary" binary is required for validation, please install it.
+        exit 1
+    fi
+done
 
 echo Running tests...
 for book in docs/*/master.adoc; do
@@ -54,9 +61,9 @@ if test -n "$failed_validations"; then
 fi
 
 if (($exit_status)); then
-    echo -e "\nTesting failed."
+    echo -e "\nTesting failed.\n"
 else
-    echo -e "\nTesting passed."
+    echo -e "\nTesting passed.\n"
 fi
 
 exit $exit_status


### PR DESCRIPTION
Resolves #529. I have included some cleanup so that it is immediately testable on a vanilla Mac.