### PR TITLE
Added pre-commit hook to prevent breaking Launchpad

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+LAUNCHPAD_INDEX="https://raw.githubusercontent.com/openshiftio/launchpad-frontend/master/src/assets/adoc.index"
+DOC_REPO_PREFIX="https://raw.githubusercontent.com/openshiftio/appdev-documentation/master/"
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=7f6bfba0c5c1ccafe2b7382dc3f625fa6bd09aca
+fi
+
+# Failing gracefully if some of the used binaries is not installed
+for binary in curl sed grep; do
+    if ! $binary --version &>/dev/null; then
+        echo -e "Trying to run pre-commit hook; '${binary}' is missing. Please install it.\nProceeding with commit anyway..." >&2
+        exit 0
+    fi
+done
+
+# Failing gracefully if the launchpad file can not be reached
+if ! index_contents="$(curl -f $LAUNCHPAD_INDEX 2>/dev/null)"; then
+    echo -e "Trying to run pre-commit hook; Could not reach index file to test. You are\nprobably offline. Proceeding with commit anyway..." >&2
+    exit 0
+fi
+
+# Check for deleted files
+index_files=$(printf \\"$index_contents\\" \
+    | sed -e 's|^.*"\([^"]*\)".*$|\1|' -e "s|$DOC_REPO_PREFIX||" -e '/^\W*$/d' )
+deleted_launchpad_files=""
+for file in $(git diff --cached --name-only --diff-filter=D $against); do
+    if printf "${index_files}" | grep -q "${file}"; then
+        deleted_launchpad_files="${deleted_launchpad_files}\n  $file"
+    fi
+done
+
+# Fail if any critical files were deleted
+if ! test -z "$deleted_launchpad_files"; then
+    echo "You have deleted the following file(s) that are required by the Launchpad app:"
+    printf "$deleted_launchpad_files"
+    echo -e "\n\nThese files are required and must not be deleted. If you want to commit anyway,\nrun the 'git commit' command with the '--no-verify' option."
+    exit 1
+fi
+

--- a/docs/topics/contributing-before-you-start.adoc
+++ b/docs/topics/contributing-before-you-start.adoc
@@ -60,3 +60,20 @@ For more information, see link:https://help.github.com/articles/signing-commits-
 ----
 $ git config --global gpg.program gpg2
 ----
+
+== Setting Up Git Hooks
+
+To make a contribution to the {repo-docs-name} repository, you need to set up the Git hooks directory. These hooks automatically make sure at commit time that your contribution does not break important parts of the repository.
+
+[discrete]
+=== Procedure
+
+.Setting up Git Hooks in {repo-docs-name} Repository
+. In a terminal application, navigate to the directory with the {repo-docs-name} repository.
+. Set the Git hook directory to `$REPO_HOME/.githooks`:
++
+[source,bash,options="nowrap"]
+----
+$ git config core.hooksPath .githooks
+----
+

--- a/docs/topics/contributing-making-changes.adoc
+++ b/docs/topics/contributing-making-changes.adoc
@@ -7,6 +7,7 @@ When making contributions, follow the standard link:https://guides.github.com/in
 == Prerequisites
 
 * A GitHub account with GPG. For more information, see xref:_accounts[].
+* The {repo-docs-name} repository cloned and xref:_setting_up_git_hooks[Git hooks set up].
 
 [discrete]
 == Procedure


### PR DESCRIPTION
This hook must be run client-side (GitHub does not allow server-side hooks, only webhooks to other services.). This means that since the hooks are in the `.git` directory and therefore not tracked by Git, they must be put in another directory (`.githooks` in this case) and the user must configure their repo instance accordingly. This is described in the Contribution Guide.

We can set up server-side checking in the `cico_build_deploy.sh` script, I believe, to verify all required files _exist,_ as opposed to _were not removed in the last commit,_ which is what the commit hook does. I realise that is a slightly different thing, but I think it's close enough.

Resolves #505.