### PR TITLE
Added script to generate changelog for a milestone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ Guardfile
 .settings
 *.orig
 *.swp
-
+.github_token
+**/CHANGELOG.temp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,12 +4,13 @@
 #specific files
 docs/contrib-guide/master.adoc @tradej
 openshift/* @gastaldi
-**/*.buildGuide.sh @rhoads-zach
-scripts/buildGuides.sh @rhoads-zach
-scripts/addGuide.sh @rhoads-zach
+**/*.build_guide.sh @rhoads-zach
+scripts/build_guides.sh @rhoads-zach
+scripts/add_guide.sh @rhoads-zach
 scripts/deploy_launchpad_mission.sh @rhoads-zach
 scripts/Dockerfile @rhoads-zach
 scripts/entrypoint.sh @gastaldi
+scripts/generate_changelog.sh @tradej
 scripts/tag_release.sh @tradej
 scripts/validate_guides.sh @tradej
 

--- a/docs/topics/contributing-releasing-new-version.adoc
+++ b/docs/topics/contributing-releasing-new-version.adoc
@@ -18,8 +18,56 @@ This section contains all information you need to release a new version of the d
 Usually, update version `vX` to `vX+1`, for example `v3` to `v4`.
 --
 
+. Update the current milestone in GitHub:
+.. Rename the _Current Development_ milestone to the current date in the _YYYY-MM-DD_ format.
+.. Create a new milestone called _Current Development._
+.. Move all open issues from the old milestone to _Current Development:_
+... Open the recently closed milestone from the link:{link-repo-docs}milestones[list of milestones].
+... Ensure you are only seeing open issues by clicking _Open._
+... Select all issues.
+... In the top right corner of the table, click _Milestone_ -> _Current Development_ to assign the selected issues to the current milestone.
+.. Close the old milestone.
+
+. Add the issues resolved in the last milestone to `CHANGELOG.adoc`:
+.. Execute the `generate_changelog.sh` script from the `$REPO_HOME/scripts` directory with the name of the milestone.
++
+--
+WARNING: Ensure you use the human-readable name of the milestone, not the numerical ID.
+
+For example, with the _2017-04-21_ milestone:
+
+[source,bash,options="nowrap"]
+----
+$ ./scripts/generate_changelog.sh '2017-04-21'
+----
+
+[NOTE]
+====
+The script asks you for a GitHub token. If you do not have such a token, generate one at link:https://github.com/settings/tokens[your GitHub token page].
+When creating the token, set the access permission for it to `public_repo`.
+
+Alternatively, you can store the access token in the `.github_token` file in `$REPO_HOME`.
+If you do that, ensure the access permissions on the `.github_token` file do not allow reading by other users.
+====
+
+The script outputs a list of issues in the AsciiDoc format to the standard output. If the output is empty, it is likely one of the following situations occurred:
+
+* You have misspelled the name of the milestone.
+* You have not specified an access token and GitHub started limiting queries from your IP address. In this case, execute the script again and input the access token when asked.
+--
+.. Copy the output of the `generate_changelog.sh` script to the `CHANGELOG.adoc` file and add a heading that points to the corresponding release.
++
+--
+For example, with the _2017-04-21_ release:
+
+[source,asciidoc,options="nowrap"]
+----
+== link:https://github.com/openshiftio/appdev-documentation/releases/tag/2017-04-21[2017-04-21 Release]
+----
+--
+
 . Tag the release:
-. Execute the `tag_release.sh` script in the `$REPO_HOME/scripts` directory:
+.. Execute the `tag_release.sh` script in the `$REPO_HOME/scripts` directory:
 +
 --
 [source,bash]
@@ -34,7 +82,7 @@ The script automatically tags the commit with the current date in the `YYYY-MM-D
 $ git tag 2017-04-21
 ----
 --
-. Push the changes and tags:
+.. Push the changes and tags:
 +
 --
 [source,bash]
@@ -44,16 +92,6 @@ $ git push --follow-tags $REMOTE
 
 Replace `$REMOTE` with the name of the upstream remote.
 --
-
-. Update the current milestone in GitHub:
-.. Rename the _Current Development_ milestone to the current date in the _YYYY-MM-DD_ format.
-.. Create a new milestone called _Current Development._
-.. Move all open issues from the old milestone to _Current Development:_
-... Open the recently closed milestone from the link:{link-repo-docs}milestones[list of milestones].
-... Ensure you are only seeing open issues by clicking _Open._
-... Select all issues.
-... In the top right corner of the table, click _Milestone_ -> _Current Development_ to assign the selected issues to the current milestone.
-.. Close the old milestone.
 
 . Request publication:
 .. File a pull request in the link:https://github.com/openshiftio/saas-launchpad/blob/master/launchpad-services/appdev-documentation.yaml#L2[openshiftio/saas-launchpad] repository, where you change the `hash` value to the hash of the commit you want to publish from the link:https://github.com/openshiftio/appdev-documentation[appdev-documentation] repository. Usually, this will be the latest commit in the `master` branch.

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+LOGHUB_TEMPFILE='CHANGELOG.temp'
+TOKEN_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../.github_token"
+
+# Get milestone to generate
+if [ $# -eq 0 ]; then
+    echo 'You must select which milestone to generate. Use the milestone name, not the numerical ID. Usage:
+
+  ./generate_changelog.sh NAME_OF_MILESTONE
+' >&2
+    exit 1
+else
+    milestone="$1"
+fi
+
+# Check if all non-standard binaries are present
+if ! loghub -h &>/dev/null; then
+    echo 'The loghub binary is missing. To install it, ensure you have pip installed
+and execute:
+
+  pip install --user loghub
+' >&2
+    exit 1
+fi
+if ! pandoc --version &>/dev/null; then
+    echo "The pandoc binary is missing, please install it." >&2
+    exit 1
+fi
+
+# Get GitHub token
+read -p 'Your GitHub token (leave empty for no authentication--not recommended): ' token
+if test -z $token; then
+    if test -f $TOKEN_FILE; then
+        echo "Loading GitHub token from file." >&2
+        token_string="--token $(cat $TOKEN_FILE)"
+    else
+        echo "No token provided, proceeding without authentication.
+Warning: Your query may be rejected by GitHub. If you get an empty result, try
+specifying a GitHub token while running the script." >&2
+        token_string=""
+    fi
+else
+    token_string="--token ${token}"
+fi
+
+# Get the issues
+test -f $LOGHUB_TEMPFILE && cleanup_needed=1
+loghub 'openshiftio/appdev-documentation' --milestone "${milestone}" $token_string | grep 'Issue ' | pandoc -f markdown -t asciidoc | tee /tmp/foo.adoc
+test -z cleanup_needed || rm $LOGHUB_TEMPFILE 2>/dev/null


### PR DESCRIPTION
Notes:

## Gitignore
* The `.github_token` file is used to store the current user's GitHub access code for making queries. The file is optional—the user can provide the token interactively or not at all. GitHub's quota may come into play in the last scenario, though.
* `CHANGELOG.temp` is a Markdown temp file that the LogHub binary creates when querying, even if the output is directly piped somewhere.

## Contrib Guide
* I moved the bullet point with updating the milestone earlier in the process so that the issues resolved can be put into CHANGELOG and committed with other changes.

## The Script
* I have tested on Fedora, FreeBSD, and Mac OS. Having said that, I'll have to return the Mac soon, so I will go back to testing on FreeBSD only.
* The script only outputs the list of issues to `stdout`, and the result must be copied to `CHANGELOG.adoc` manually. Manipulating the file itself using the script has proven to be quite tricky in regard to corner cases and assumptions. I don't think it saves enough time to warrant the extra work.

Resolves #456.