### PR TITLE
 Issue 554: added links to stage environments for launcher and docs to Contrib Guide

### DIFF
--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -9,6 +9,8 @@ include::topics/templates/document-attributes.adoc[]
 
 _TBD_
 
+You can preview the latest state of {launcher} by navigating to the link:{launcher-stage}[stage build] of {launcher}.
+
 == File a Code Issue
 
 _TBD_

--- a/docs/topics/contributing-releasing-new-version.adoc
+++ b/docs/topics/contributing-releasing-new-version.adoc
@@ -94,6 +94,5 @@ Replace `$REMOTE` with the name of the upstream remote.
 --
 
 . Request publication:
-.. File a pull request in the link:https://github.com/openshiftio/saas-launchpad/blob/master/launchpad-services/appdev-documentation.yaml#L2[openshiftio/saas-launchpad] repository, where you change the `hash` value to the hash of the commit you want to publish from the link:https://github.com/openshiftio/appdev-documentation[appdev-documentation] repository. Usually, this will be the latest commit in the `master` branch.
-.. Wait for the pull request to be accepted. When that happens, verify that the link:https://appdev.prod-preview.openshift.io/[stage build] succeeded.
-
+.. File a pull request in the link:https://github.com/openshiftio/saas-launchpad/blob/master/launchpad-services/appdev-documentation.yaml#L2[openshiftio/saas-launchpad] repository, where you change the `hash` value to the hash of the commit you want to publish from the link:{link-repo-docs}[appdev-documentation] repository. Usually, this will be the latest commit in the `master` branch.
+.. Wait for the pull request to be accepted. When that happens, verify that the link:{docs-stage}[stage build] succeeded.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -144,3 +144,7 @@
 
 :docs-name: appdev.openshift.io
 :link-docs: https://appdev.openshift.io
+
+// stage environment URLs for Docs and Launcher
+:link-docs-stage: https://appdev.prod-preview.openshift.io/
+:link-launcher-stage: https://launch.prod-preview.openshift.io/


### PR DESCRIPTION
resolves #554

also created the corresponding attributes in `document-attributes.adoc`