### PR TITLE
added Release Notes Component Label and description

### DIFF
--- a/docs/topics/contributing-labels.adoc
+++ b/docs/topics/contributing-labels.adoc
@@ -130,4 +130,5 @@ Use the following labels to describe what runtimes, mission, or components an is
 | `Component \| Minishift Guide` | The issue or pull request relates to the Minishift Installation Guide.
 | `Component \| Frontend` | The issue or pull request relates to the frontend HTMLs etc.
 | `Component \| Infrastructure` | The issue or pull request relates to publishing, building, CI, etc.
+| `Component \| Release Notes` | The issue or pull request relates to information to be included in the Release Notes.
 |===


### PR DESCRIPTION
I added this label to track issue that should be listed in the release notes.
Even though the release notes will be published on the Customer Portal, I'm still in favor of tracking RN-related issues here to keep things in one place.
Since the RN are not developed in this repo, I intended this label to be used for issues rather that PRs.
@tradej Please let me know what you think and merge if this LGTY. 