### PR TITLE
Issue #564: unified pod name examples in booster deployment sections

### DIFF
--- a/docs/topics/circuit-breaker-mission-deploy-booster.adoc
+++ b/docs/topics/circuit-breaker-mission-deploy-booster.adoc
@@ -41,13 +41,13 @@ This command uses the Fabric8 Maven Plugin to launch the S2I process on your {Op
 ----
 $ oc get pods -w
 NAME                            READY     STATUS      RESTARTS  AGE
-{app-name}-greeting-1-p2x5m     1/1       Running   0           17s
+{app-name}-greeting-1-aaaaa     1/1       Running   0           17s
 {app-name}-greeting-1-deploy    0/1       Completed 0           22s
-{app-name}-name-1-7mffj         1/1       Running   0           14s
+{app-name}-name-1-aaaaa         1/1       Running   0           14s
 {app-name}-name-1-deploy        0/1       Completed 0           28s
 ----
 +
-Both the `{app-name}-greeting` and `{app-name}-name` pods should have a status of `Running` once they are fully deployed and started. You should also wait for your pods to be ready before proceeding, which is shown in the `READY` column. For example, `PROJECT_NAME-1-aaaaa` is ready when the `READY` column is `1/1`.
+Both the `{app-name}-greeting-1-aaaaa` and `{app-name}-name-1-aaaaa` pods should have a status of `Running` once they are fully deployed and started. You should also wait for your pods to be ready before proceeding, which is shown in the `READY` column. For example, `PROJECT_NAME-1-aaaaa` is ready when the `READY` column is `1/1`.
 // :app-name: springboot-cb
 
 . Once your booster is deployed and started, determine its route.

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -8,7 +8,7 @@ include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 
-. Get your authentication token for using the `oc` CLI client with your {OpenShiftLocal} account. You can find this in the _Command Line Tools_ section your {OpenShiftLocal} Web console. 
+. Get your authentication token for using the `oc` CLI client with your {OpenShiftLocal} account. You can find this in the _Command Line Tools_ section your {OpenShiftLocal} Web console.
 
 . Authenticate your `oc` CLI client with your {OpenShiftLocal} account by using your authentication token.
 +

--- a/docs/topics/crud-mission-deploy-booster.adoc
+++ b/docs/topics/crud-mission-deploy-booster.adoc
@@ -38,11 +38,11 @@ $ oc new-app -e POSTGRESQL_USER=luke -ePOSTGRESQL_PASSWORD=secret -ePOSTGRESQL_D
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc get pods -w
-my-database-1-7c7m0   1/1       Running   0         45s
+my-database-1-aaaaa   1/1       Running   0         45s
 my-database-1-deploy   0/1       Completed   0         53s
 ----
 +
-Your `my-database` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
+Your `my-database-1-aaaaa` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
 
 ifndef::http-api-nodejs[]
 . Use maven to start the deployment to {OpenShiftLocal}.
@@ -76,7 +76,7 @@ NAME                             READY     STATUS      RESTARTS   AGE
 {app-name}-s2i-1-build   0/1       Completed   0          2m
 ----
 +
-Your `{app-name}` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
+Your `{app-name}-1-aaaaa` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
 
 . Once your booster is deployed and started, determine its route.
 +

--- a/docs/topics/health-check-mission-deploy-booster.adoc
+++ b/docs/topics/health-check-mission-deploy-booster.adoc
@@ -55,11 +55,11 @@ endif::http-api-nodejs[]
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-qqa2d   1/1       Running   0           14s
+{app-name}-1-aaaaa   1/1       Running   0           14s
 {app-name}-1-deploy  0/1       Completed 0           22s
 ----
 +
-Your `health-check` pod should have a status of `Running` once it's fully deployed and started. You should also wait for your pod to be ready before proceeding, which is shown in the `READY` column. For example, `PROJECT_NAME-1-aaaaa` is ready when the `READY` column is `1/1`.
+Your `{app-name}-1-aaaaa` pod should have a status of `Running` once it's fully deployed and started. You should also wait for your pod to be ready before proceeding, which is shown in the `READY` column. For example, `PROJECT_NAME-1-aaaaa` is ready when the `READY` column is `1/1`.
 
 
 . Once your booster is deployed and started, determine its route.

--- a/docs/topics/rest-level-0-mission-deploy-booster.adoc
+++ b/docs/topics/rest-level-0-mission-deploy-booster.adoc
@@ -58,7 +58,7 @@ NAME                             READY     STATUS      RESTARTS   AGE
 {app-name}-s2i-1-build           0/1       Completed   0          2m
 ----
 +
-You `app1` pod should have a status of `Running` once its fully deployed and started.
+You `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
 
 . Once your booster is deployed and started, determine its route.
 +


### PR DESCRIPTION
Where applicable, pod names examples in `oc get routes` output examples within booster deployment sections are now given as  `{app-name}-1-aaaaa`.
Changes affect all missions except Secured.

resolved #564 
 @gytis WDYT?