### PR TITLE
fix wording in Deploy your Booster to OpenShift Online

### DIFF
--- a/docs/topics/booster-deploy-openshift-online.adoc
+++ b/docs/topics/booster-deploy-openshift-online.adoc
@@ -1,3 +1,3 @@
 = Deploy your Booster to {OpenShiftOnline}
 
-Navigate to link:{link-launcher-oso}[{launcher}] in {OpenShiftOnline} and use it to create and launch your booster. You can also use the `oc` CLI Client to deploy a booster to {OpenShiftOnline}. To use the `oc` CLI Client with {OpenShiftOnline}, you follow the same steps as with your {OpenShiftLocal} but use the authentication token and URL from the {OpenShiftOnline} Web Console.
+Navigate to link:{link-launcher-oso}[{launcher}] and use it to create and launch your booster. You can also use the `oc` CLI Client to deploy a booster to {OpenShiftOnline}. To use the `oc` CLI Client with {OpenShiftOnline}, you follow the same steps as with your {OpenShiftLocal} but use the authentication token and URL from the {OpenShiftOnline} Web Console.


### PR DESCRIPTION
Rendered, the text looks like

> Navigate to launch.openshift.io in OpenShift Online and use it to create and launch your booster

This is wrong. You don't navigate to launch.openshift.io in OpenShift Online. You just navigate to launch.openshift.io.