### PR TITLE
Checking launchpad files in the container build

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-LAUNCHPAD_INDEX="https://raw.githubusercontent.com/openshiftio/launchpad-frontend/master/src/assets/adoc.index"
-DOC_REPO_PREFIX="https://raw.githubusercontent.com/openshiftio/appdev-documentation/master/"
+# This script runs pre-commit tests and fails when any of those fail with the
+# respective script's return value. For this reason, return values for this
+# script are not well-defined and will likely change over time.
+
 SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
 
 if git rev-parse --verify HEAD >/dev/null 2>&1
@@ -12,36 +14,25 @@ else
 	against=7f6bfba0c5c1ccafe2b7382dc3f625fa6bd09aca
 fi
 
-# Failing gracefully if some of the used binaries is not installed
-for binary in curl sed grep; do
-    if ! $binary --version &>/dev/null; then
-        echo -e "Trying to run pre-commit hook; '${binary}' is missing. Please install it.\nProceeding with commit anyway..." >&2
-        exit 0
-    fi
-done
+# Redirect all output to STDERR because we don't want to break someone's workflow with
+# unexpected error messages in STDOUT
+exec 1>&2
 
-# Failing gracefully if the launchpad file can not be reached
-if ! index_contents="$(curl -f $LAUNCHPAD_INDEX 2>/dev/null)"; then
-    echo -e "Trying to run pre-commit hook; Could not reach index file to test. You are\nprobably offline. Proceeding with commit anyway..." >&2
-    exit 0
-fi
+# Fail on non-zero retval
+set -e
 
-# Check for deleted files
-index_files=$(printf \\"$index_contents\\" \
-    | sed -e 's|^.*"\([^"]*\)".*$|\1|' -e "s|$DOC_REPO_PREFIX||" -e '/^\W*$/d' )
-deleted_launchpad_files=""
-for file in $(git diff --cached --name-only --diff-filter=D $against); do
-    if printf "${index_files}" | grep -q "${file}"; then
-        deleted_launchpad_files="${deleted_launchpad_files}\n  $file"
-    fi
-done
+echo "[POLICY] === Executing Commit Hook ==="
 
-# Fail if any critical files were deleted
-if ! test -z "$deleted_launchpad_files"; then
-    echo "You have deleted the following file(s) that are required by the Launchpad app:"
-    printf "$deleted_launchpad_files"
-    echo -e "\n\nThese files are required and must not be deleted. If you want to commit anyway,\nrun the 'git commit' command with the '--no-verify' option."
+# Check launchpad files
+GIT_AVAILABLE=1 ${SCRIPT_SRC}/../scripts/check_launchpad.sh 2>&1 | (sed -e 's/^/[POLICY] /')
+# 2 is returned if binaries are missing or the index is unreachable.
+# We don't want to block the commit on that. Using PIPESTATUS because otherwise
+# we'd check for the retval of sed instead of check_launchpad.sh
+success=${PIPESTATUS[0]}
+if [ $success -ne 0 -a $success -ne 2 ]; then
     exit 1
+elif [ $success -eq 2 ]; then
+    echo "[POLICY] Verification aborted. Continuing..."
 fi
 
 # Validate books

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -12,5 +12,7 @@ RUN yum install -y rubygems libxml2 && \
 COPY scripts/ scripts/
 COPY docs/ docs/
 
+RUN scripts/check_launchpad.sh
+
 RUN scripts/validate_guides.sh
 

--- a/scripts/build_guides.sh
+++ b/scripts/build_guides.sh
@@ -7,7 +7,7 @@ BUILD_MESSAGE=$BUILD_RESULTS
 # Move to docs dir
 cd $DOCS_SRC
 
-echo "=== Building all the guides ==="
+echo "=== Building Guides ==="
 # Recurse through the guide directories and build them.
 subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "topics" | sort`
 

--- a/scripts/check_launchpad.sh
+++ b/scripts/check_launchpad.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Check if files used by openshiftio/launchpad-frontend were deleted. Returns 2
+# on a tooling issue, returns 1 if deleted files were detected.
+#
+# Works by either analyzing the Git diff or by checking the files on the
+# filesystem, depending on Git being available. You can provide this
+# information by setting the GIT_AVAILABLE variable when running the script.
+#
+# NOTE: In the container docs build on ci.centos.org, Git is NOT available.
+
+LAUNCHPAD_INDEX="https://raw.githubusercontent.com/openshiftio/launchpad-frontend/master/src/assets/adoc.index"
+DOC_REPO_PREFIX="https://raw.githubusercontent.com/openshiftio/appdev-documentation/master/"
+
+echo "=== Verifying Launchpad Files ==="
+
+# Failing gracefully if some of the used binaries is not installed
+for binary in curl sed grep; do
+    if ! $binary --version &>/dev/null; then
+        echo -e "The '${binary}' binary is missing. Please install it."
+        exit 2
+    fi
+done
+
+# Failing gracefully if the launchpad file can not be reached
+if ! index_contents="$(curl -f $LAUNCHPAD_INDEX 2>/dev/null)"; then
+    echo -e "Could not reach index file to test. You are probably offline."
+    exit 2
+fi
+
+index_files=$(printf \\"$index_contents\\" \
+    | sed -e 's|^.*"\([^"]*\)".*$|\1|' -e "s|$DOC_REPO_PREFIX||" -e '/^\W*$/d' )
+
+# Check for deleted files if in Git environment
+deleted_launchpad_files=""
+if ! test -z $GIT_AVAILABLE; then
+    for file in $(git diff --cached --name-only --diff-filter=D $against); do
+        if printf "${index_files}" | grep -q "${file}"; then
+            deleted_launchpad_files="${deleted_launchpad_files}\n  $file"
+        fi
+    done
+# Check if files exist in non-Git environment
+else
+    for file in $(printf "$index_files"); do
+        if ! test -f $file; then
+            deleted_launchpad_files="${deleted_launchpad_files}\n  $file"
+        fi
+    done
+fi
+
+# Fail if any critical files were deleted
+if ! test -z "$deleted_launchpad_files"; then
+    echo "The following file(s) were deleted, which are required by the Launchpad app:"
+    printf "$deleted_launchpad_files"
+    echo -e '\n'
+    test -z $GIT_AVAILABLE || echo -e "These files are required and must not be deleted. If you want to commit anyway,\nrun the 'git commit' command with the '--no-verify' option."
+    exit 1
+else
+    echo "Success."
+    exit 0
+fi
+

--- a/scripts/validate_guides.sh
+++ b/scripts/validate_guides.sh
@@ -12,7 +12,7 @@ for binary in asciidoctor xmllint; do
     fi
 done
 
-echo "= Validating books... ="
+echo "=== Validating Guides ==="
 
 for book in docs/*/master.adoc; do
     dir="$(dirname $book)"


### PR DESCRIPTION
Notes:
* The part of the pre-commit hook that checks launchpad files for deletion was externalised into `check_launchpad.sh`. This script accepts and env. variable `GIT_AVAILABLE`, which determines if it looks at the Git changes or at the filesystem.
* The `check_launchpad.sh` script is called both in the pre-commit hook and in the `Dockerfile.build` file, which means it's run at commit time (with Git changes) and both in the PR and master CI builds.

@rhoads-zach, please test the script on your Mac. Instructions:
* Run the `check_launchpad.sh` script without changes in the repository. Should run fine and output:
```
= Verifying launchpad files... =
Success.
```

* `rm -rf` the whole `docs/topics/frontend` directory and run the `check_launchpad.sh` script. Should return 1 and output:
```
= Verifying launchpad files... =
The following file(s) were deleted, which are required by the Launchpad app:

  docs/topics/frontend/getting-started-mission-intro.adoc
  docs/topics/frontend/github-create-step.adoc
  docs/topics/frontend/github-pushed-step.adoc
  docs/topics/frontend/openshift-create-step.adoc
  docs/topics/frontend/openshift-pipeline-step.adoc
  docs/topics/frontend/github-webhook.adoc

```

* Immediately after that, run `check_launchpad.sh` after setting `GIT_AVAILABLE` to `1`. Should run fine and output:
```
= Verifying launchpad files... =
Success.
```
(The changes were not staged for commit, so Git gives you a clean changeset)

* `git add` the `docs` directory and run `check_launchpad.sh` after setting `GIT_AVAILABLE` to `1`. Should return 1 and output:
```
= Verifying launchpad files... =
The following file(s) were deleted, which are required by the Launchpad app:

  docs/topics/frontend/getting-started-mission-intro.adoc
  docs/topics/frontend/github-create-step.adoc
  docs/topics/frontend/github-pushed-step.adoc
  docs/topics/frontend/github-webhook.adoc
  docs/topics/frontend/openshift-create-step.adoc
  docs/topics/frontend/openshift-pipeline-step.adoc

These files are required and must not be deleted. If you want to commit anyway,
run the 'git commit' command with the '--no-verify' option.
```

Thank you. Resolves #586.