### PR TITLE
Proper means to reference multiple mvn profiles

### DIFF
--- a/docs/topics/crud-mission-integration-testing.adoc
+++ b/docs/topics/crud-mission-integration-testing.adoc
@@ -8,5 +8,5 @@ To run the integration tests, execute the following command:
 
 [source,bash,option="nowrap"]
 --
-mvn clean verify -Popenshift -Popenshift-it
+mvn clean verify -Popenshift,openshift-it
 --


### PR DESCRIPTION
According to http://maven.apache.org/guides/introduction/introduction-to-profiles.html multiple profiles are referenced as a comma separated list:

"This option takes an argument that is a comma-delimited list of profile-ids to use."