### PR TITLE
Issue #616: added note about code download

### DIFF
--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -23,6 +23,8 @@ include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
 include::topics/rest-level-0-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/rest-level-0-mission-design-tradeoffs.adoc[leveloffset=+3]
 
 include::topics/rest-level-0-mission-deploy-booster.adoc[leveloffset=+3]
@@ -39,6 +41,8 @@ include::topics/rest-level-0-mission-resources.adoc[leveloffset=+3]
 
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
 
 include::topics/crud-mission-deploy-booster.adoc[leveloffset=+3]
@@ -53,6 +57,8 @@ include::topics/crud-mission-resources.adoc[leveloffset=+3]
 :health-check-nodejs:
 
 include::topics/health-check-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-deploy-booster.adoc[leveloffset=+3]
 

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -27,6 +27,8 @@ include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
 include::topics/rest-level-0-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/rest-level-0-mission-design-tradeoffs.adoc[leveloffset=+3]
 
 include::topics/rest-level-0-mission-deploy-booster.adoc[leveloffset=+3]
@@ -41,6 +43,8 @@ include::topics/rest-level-0-mission-resources.adoc[leveloffset=+3]
 :configmap-spring-boot-tomcat:
 
 include::topics/configmap-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/configmap-mission-design-tradeoffs.adoc[leveloffset=+3]
 
@@ -60,6 +64,8 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // design tradeoffs
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
@@ -84,6 +90,8 @@ include::topics/crud-mission-resources.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/health-check-mission-deploy-booster.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc[leveloffset=+3]
@@ -98,6 +106,8 @@ include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 // circuit breaker intro
 include::topics/circuit-breaker-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // CB design tradeoffs
 include::topics/circuit-breaker-mission-design-tradeoffs.adoc[leveloffset=+3]
@@ -126,14 +136,14 @@ include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/secured-mission-intro-paragraph.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/secured-booster-minishift.adoc[leveloffset=+3]
 
 include::topics/secured-mission-intro.adoc[leveloffset=+3]
 
 //this needs to be a level lower due to secured-mission-intro.adoc
 include::topics/secured-mission-springboot-adapter.adoc[leveloffset=+4]
-
-
 
 include::topics/secured-mission-deploy-booster.adoc[leveloffset=+3]
 

--- a/docs/topics/note-preview-booster-source.adoc
+++ b/docs/topics/note-preview-booster-source.adoc
@@ -1,0 +1,1 @@
+NOTE: To view the source code and README file of this Booster, link:{link-getting-started-guide}#oso-create-booster[download and extract the Booster ZIP file].

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -24,6 +24,8 @@ include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
 include::topics/rest-level-0-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/rest-level-0-mission-design-tradeoffs.adoc[leveloffset=+3]
 
 include::topics/rest-level-0-mission-deploy-booster.adoc[leveloffset=+3]
@@ -38,6 +40,8 @@ include::topics/rest-level-0-mission-resources.adoc[leveloffset=+3]
 :configmap-vertx:
 
 include::topics/configmap-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/configmap-mission-design-tradeoffs.adoc[leveloffset=+3]
 
@@ -57,6 +61,8 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
 
@@ -78,6 +84,8 @@ include::topics/crud-mission-resources.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/health-check-mission-deploy-booster.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-basic-interaction-vertx.adoc[leveloffset=+3]
@@ -93,6 +101,8 @@ include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 // circuit breaker intro
 include::topics/circuit-breaker-mission-intro.adoc[leveloffset=+3]
 //TODO
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // CB design tradeoffs
 include::topics/circuit-breaker-mission-design-tradeoffs.adoc[leveloffset=+3]
@@ -125,6 +135,8 @@ include::topics/circuit-breaker-mission-resources.adoc[leveloffset=+3]
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/secured-mission-intro-paragraph.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/secured-booster-minishift.adoc[leveloffset=+3]
 

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -24,6 +24,8 @@ include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
 include::topics/rest-level-0-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/rest-level-0-mission-design-tradeoffs.adoc[leveloffset=+3]
 
 include::topics/rest-level-0-mission-deploy-booster.adoc[leveloffset=+3]
@@ -38,6 +40,8 @@ include::topics/rest-level-0-mission-resources.adoc[leveloffset=+3]
 :configmap-wf-swarm:
 
 include::topics/configmap-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/configmap-mission-design-tradeoffs.adoc[leveloffset=+3]
 
@@ -56,6 +60,8 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // design tradeoffs
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
@@ -79,6 +85,8 @@ include::topics/crud-mission-resources.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-intro.adoc[leveloffset=+3]
 
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
+
 include::topics/health-check-mission-deploy-booster.adoc[leveloffset=+3]
 
 include::topics/health-check-mission-basic-interaction-wf-swarm.adoc[leveloffset=+3]
@@ -93,6 +101,8 @@ include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 // circuit breaker intro
 include::topics/circuit-breaker-mission-intro.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // CB design tradeoffs
 include::topics/circuit-breaker-mission-design-tradeoffs.adoc[leveloffset=+3]
@@ -123,6 +133,8 @@ include::topics/circuit-breaker-mission-resources.adoc[leveloffset=+3]
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
 include::topics/secured-mission-intro-paragraph.adoc[leveloffset=+3]
+
+include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/secured-booster-minishift.adoc[leveloffset=+3]
 


### PR DESCRIPTION
resolves #616 

@liborfuka @Ladicek: Would a note like this be OK? Since we have the ZIP download instructions already documented I included a link to the appropriate section of the GSG.
Please let me know WDYT and if it's ok, I'll include the note at the top of each Mission chapter. 

As I mentioned in the discussion on #616, there is also the alternative of linking directly to the repo on GitHub that hosts the booster code.