### PR TITLE
Do not import env as it's not used anyway

### DIFF
--- a/cico_build_test.sh
+++ b/cico_build_test.sh
@@ -8,8 +8,8 @@ TARGET_DIR="html"
 # Exit on error
 set -e
 
-[ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT > inherit-env
-[ -f inherit-env ] && . inherit-env
+#[ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT_COMMIT -e DEVSHIFT > inherit-env
+#[ -f inherit-env ] && . inherit-env
 
 # We need to disable selinux for now, XXX
 /usr/sbin/setenforce 0


### PR DESCRIPTION
This fixes failing builds for https://github.com/openshiftio/appdev-documentation/pull/609 - the problem there was env var `ghprbPullLongDescription` got imported (see https://ci.centos.org/job/devtools-appdev-documentation/87/console) and for some reason sourcing failed. 

I removed the env import as none of the env vars are used anyway. 