### PR TITLE
Fixed headings

### DIFF
--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -13,7 +13,7 @@ include::topics/assembly-updating-booster-catalog-for-local-minishift-testing.ad
 
 You can preview the latest state of {launcher} by navigating to the link:{launcher-stage}[stage build] of {launcher}.
 
-== File a Code Issue
+== Filing a Code Issue
 
 _TBD_
 

--- a/docs/topics/appendix-configure-launcher-sso-realm.adoc
+++ b/docs/topics/appendix-configure-launcher-sso-realm.adoc
@@ -1,5 +1,5 @@
 [[launcher-sso-settings]]
-= Configure {launcher} {RHSSO} Federated Identity Settings
+= Configuring {launcher} {RHSSO} Federated Identity Settings
 
 In order to use {launcher}, you must grant it access to your GitHub and OpenShift accounts. This is a one-time action.
 

--- a/docs/topics/appendix-configure-launcher-sso-realm.adoc
+++ b/docs/topics/appendix-configure-launcher-sso-realm.adoc
@@ -1,5 +1,5 @@
 [[launcher-sso-settings]]
-= Configure Your {launcher} {RHSSO} Federated Identity Settings
+= Configure {launcher} {RHSSO} Federated Identity Settings
 
 In order to use {launcher}, you must grant it access to your GitHub and OpenShift accounts. This is a one-time action.
 

--- a/docs/topics/booster-deploy-openshift-local.adoc
+++ b/docs/topics/booster-deploy-openshift-local.adoc
@@ -1,4 +1,4 @@
-= Deploy the Booster to a {OpenShiftLocal}
+= Deploying the Booster to a {OpenShiftLocal}
 
 . Before you can use a {OpenShiftLocal}, you need to have it installed, configured, and running. You can find more details in link:{link-openshift-local-guide}#install-local-cloud[{openshift-local-guide-name}].
 
@@ -22,7 +22,7 @@
        oc login -u system:admin
 ----
 
-== Deploy Using {launcher}
+== Deploying Using {launcher}
 
 Once you have the {launcher} application link:{link-launcher-openshift-local-install-guide}[installed and configured],
 navigate to it in your {OpenShiftLocal} and use it to create and launch your booster.

--- a/docs/topics/booster-deploy-openshift-local.adoc
+++ b/docs/topics/booster-deploy-openshift-local.adoc
@@ -1,4 +1,4 @@
-= Deploy your Booster to a {OpenShiftLocal}
+= Deploy the Booster to a {OpenShiftLocal}
 
 . Before you can use a {OpenShiftLocal}, you need to have it installed, configured, and running. You can find more details in link:{link-openshift-local-guide}#install-local-cloud[{openshift-local-guide-name}].
 

--- a/docs/topics/booster-deploy-openshift-online.adoc
+++ b/docs/topics/booster-deploy-openshift-online.adoc
@@ -1,3 +1,3 @@
-= Deploy your Booster to {OpenShiftOnline}
+= Deploying your Booster to {OpenShiftOnline}
 
 Navigate to link:{link-launcher-oso}[{launcher}] and use it to create and launch your booster. You can also use the `oc` CLI Client to deploy a booster to {OpenShiftOnline}. To use the `oc` CLI Client with {OpenShiftOnline}, you follow the same steps as with your {OpenShiftLocal} but use the authentication token and URL from the {OpenShiftOnline} Web Console.

--- a/docs/topics/build-and-deploy-process.adoc
+++ b/docs/topics/build-and-deploy-process.adoc
@@ -1,5 +1,5 @@
 [[build-and-deploy-process]]
-= Build and Deploy to OpenShift Build Process
+= Building and Deploying to OpenShift Build Process
 
 When using {launcher}, you have the option to create and deploy a booster to OpenShift using the _Build and Deploy to OpenShift_ build process, which is based on link:{link-wf-swarm-runtime-guide}#s2i-build-process[the Source-to-Image (S2I) build process]. _Build and Deploy to OpenShift_ configures your booster's code to be built by OpenShift and deployed to OpenShift on each push to the master branch of your booster's GitHub repository. The benefit of this process is that it handles all the configuration, building, and deployment steps needed to get your booster's code running in OpenShift. It also allows you to quickly deploy code updates to help you rapidly iterate and see your changes in OpenShift. 
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-nodejs.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-nodejs.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {NodeJS} Booster
+= Interacting with the Unmodified {NodeJS} Booster
 
 Once you have the {NodeJS} booster deployed, you have the following services running:
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {SpringBoot} Booster
+= Interacting with the Unmodified {SpringBoot} Booster
 
 Once you have the {SpringBoot} booster deployed, you have the following services running:
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-vertx.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {Vertx} Booster
+= Interacting with the Unmodified {Vertx} Booster
 
 Once you have the {Vertx} booster deployed, you have the following services running:
 

--- a/docs/topics/circuit-breaker-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/circuit-breaker-mission-basic-interaction-wf-swarm.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {WildFlySwarm} Booster
+= Interacting with the Unmodified {WildFlySwarm} Booster
 
 Once you have the {WildFlySwarm} booster deployed, you have the following services running:
 

--- a/docs/topics/circuit-breaker-mission-deploy-booster.adoc
+++ b/docs/topics/circuit-breaker-mission-deploy-booster.adoc
@@ -1,5 +1,5 @@
 [[build_and_deploy_booster]]
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 

--- a/docs/topics/circuit-breaker-mission-deploy-booster.adoc
+++ b/docs/topics/circuit-breaker-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 [[build_and_deploy_booster]]
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 [[deploy-booster-osl-cli]]
-=== Deploy Using the `oc` CLI Client
+=== Deploying Using the `oc` CLI Client
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 

--- a/docs/topics/circuit-breaker-mission-intro.adoc
+++ b/docs/topics/circuit-breaker-mission-intro.adoc
@@ -10,7 +10,7 @@ The Circuit Breaker is a pattern intended to mitigate the impact of network fail
 Essentially, the Circuit Breaker acts as a proxy between a protected function and a remote function, which monitors for failures. Once the failures reach a certain threshold, the circuit breaker trips, and all further calls to the circuit breaker return with an error or a predefined fallback response, without the protected call being made at all. The Circuit Breaker usually also contain an error reporting mechanism that notifies you when the Circuit Breaker trips.
 
 
-= Why is Circuit Breaker Important
+= Why Circuit Breaker is Important
 
 In an architecture where multiple services depend on each other for functionality, a failure in one service can rapidly propagate to its dependent services, causing the entire architecture to collapse. Implementing a Circuit Breaker pattern helps prevent this.
 With the Circuit Breaker pattern implemented, a service client invokes a remote service endpoint via a proxy at regular intervals. If the calls to the remote service endpoint fail repeatedly and consistently, the Circuit Breaker trips, making all calls to the service fail immediately over a set timeout period and returns a predefined fallback response. When the timeout period expires, a limited number of test calls are allowed to pass through to the remote service to determine whether it has healed, or remains unavailable. If these test calls fail, the Circuit Breaker keeps the service unavailable and keeps returning the fallback responses to incoming calls. If the test calls succeed, the Circuit Breaker closes, fully enabling traffic to reach the remote service again.

--- a/docs/topics/configmap-mission-basic-interaction-nodejs.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-nodejs.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {NodeJS} Booster
+= Interacting with the Unmodified {NodeJS} Booster
 
 The booster provides a default HTTP endpoint that accepts `GET` requests.
 

--- a/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {SpringBoot} Booster
+= Interacting with the Unmodified {SpringBoot} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/configmap-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-vertx.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {VertX} Booster
+= Interacting with the Unmodified {VertX} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/configmap-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/configmap-mission-basic-interaction-wf-swarm.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {WildFlySwarm} Booster
+= Interacting with the Unmodified {WildFlySwarm} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 [[configmap_build_and_deploy_booster]]
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 
-=== Deploy Using the `oc` CLI Client
+=== Deploying Using the `oc` CLI Client
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 

--- a/docs/topics/configmap-mission-deploy-booster.adoc
+++ b/docs/topics/configmap-mission-deploy-booster.adoc
@@ -1,5 +1,5 @@
 [[configmap_build_and_deploy_booster]]
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 

--- a/docs/topics/configmap-mission-intro.adoc
+++ b/docs/topics/configmap-mission-intro.adoc
@@ -10,6 +10,6 @@ This mission shows you how to:
 
 _ConfigMap_ is an object used by OpenShift to inject configuration data as simple key and value pairs into one or more Linux containers while keeping the containers agnostic of OpenShift. You can create a ConfigMap object in a variety of different ways, including using a YAML file, and inject it into the Linux container. You can find more information about ConfigMap in the link:https://docs.openshift.org/latest/dev_guide/configmaps.html[OpenShift documentation].
 
-= Why is ConfigMap Important?
+= Why ConfigMap is Important
 
 It is important for an application's configuration to be externalized and separate from it's code. This allows for the application's configuration to change as it moves through different environments while leaving the code unchanged. This also keeps sensitive or internal information out of your codebase and version control. Many languages and application servers provide environment variables to support externalizing an application's configuration. Microservices and Linux containers increase the complexity of this by adding pods, or groups of containers representing a deployment, and polyglot environments. ConfigMap enables application configuration to be externalized and used in individual Linux containers and pods in a language agnostic way. ConfigMap also allows sets of configuration data to be easily grouped and scaled, which enables you to configure an arbitrarily large number of environments beyond the basic _Dev_, _Stage_, and _Production_.

--- a/docs/topics/crud-mission-deploy-booster.adoc
+++ b/docs/topics/crud-mission-deploy-booster.adoc
@@ -1,5 +1,5 @@
 [[crud-build_and_deploy_booster]]
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 

--- a/docs/topics/crud-mission-deploy-booster.adoc
+++ b/docs/topics/crud-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 [[crud-build_and_deploy_booster]]
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 [[crud-deploy-booster-osl-cli]]
-=== Deploy Using the `oc` CLI Client
+=== Deploying Using the `oc` CLI Client
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 

--- a/docs/topics/getting-started-cd-osl.adoc
+++ b/docs/topics/getting-started-cd-osl.adoc
@@ -1,4 +1,4 @@
-= Build and Deploy Using {OpenShiftLocal}
+= Building and Deploying Using {OpenShiftLocal}
 
 In addition to building on your local machine and pushing to a local or public cloud, you also have the ability to set up continuous delivery for a booster. Specifically, you can use the {launcher} application to clone a new booster repository to your GitHub account and have it deployed to your {OpenShiftLocal}.
 

--- a/docs/topics/getting-started-cd-oso.adoc
+++ b/docs/topics/getting-started-cd-oso.adoc
@@ -1,5 +1,5 @@
 [[cd-oso]]
-= Continuous Delivery using {OpenShiftOnline}
+= Continuous Delivery Using {OpenShiftOnline}
 
 After using {launcher} to launch your booster, click the _See it here!_ link under _Creating your project on the OpenShift cloud_ to go to your booster's page in the OpenShift Web console.
 

--- a/docs/topics/getting-started-change-locally.adoc
+++ b/docs/topics/getting-started-change-locally.adoc
@@ -1,4 +1,4 @@
-= Make Changes Locally
+= Making Changes Locally
 
 . Stop your booster.
 . Open your project in your desired IDE or editor, such as xref:use_devstudio[Developer Studio].

--- a/docs/topics/getting-started-create-booster.adoc
+++ b/docs/topics/getting-started-create-booster.adoc
@@ -1,5 +1,5 @@
 [[oso-create-booster]]
-= Create a Booster
+= Creating a Booster
 
 . Navigate to link:{link-launcher-oso}[{launcher}] using your browser.
 . Select _Launch your Project_.

--- a/docs/topics/getting-started-install-launchpad-openshift-local.adoc
+++ b/docs/topics/getting-started-install-launchpad-openshift-local.adoc
@@ -1,4 +1,4 @@
-= Install the {launcher} Application on a {OpenShiftLocal}
+= Installing the {launcher} Application on a {OpenShiftLocal}
 
 The {launcher} application is where everything starts. It helps you create projects called _boosters_ intended to jumpstart your development with a fully-working application. Each booster fulfills a _mission_, which defines the primary objective of your new project.  As an example, a mission might define how to open an HTTP endpoint or interact with a relational database.  Over time we will continue to grow the available missions, showing you how to accomplish tasks common to real enterprise development. Since {launcher} sets you up with a continuous delivery pipeline, you can evolve the example to fit your needs.
 

--- a/docs/topics/getting-started-launchpad-create-booster.adoc
+++ b/docs/topics/getting-started-launchpad-create-booster.adoc
@@ -1,5 +1,5 @@
 [[launcher-create-booster]]
-= Use the {launcher} Application to Launch a Booster
+= Using the {launcher} Application to Launch a Booster
 
 After you have the {launcher} application running on your {OpenShiftLocal}, you can use it to create a new project, your booster.
 

--- a/docs/topics/getting-started-launchpad-create-runtime-project-framework.adoc
+++ b/docs/topics/getting-started-launchpad-create-runtime-project-framework.adoc
@@ -1,5 +1,5 @@
 [[launcher-create-runtime-project-framework]]
-= Use {launcher} to Create a Runtime Project Framework Project
+= Using {launcher} to Create a Runtime Project Framework Project
 
 After you have the {launcher} application running on your {OpenShiftLocal}, you can use it to create a runtime project framework project.
 

--- a/docs/topics/getting-started-launchpad-launch-booster.adoc
+++ b/docs/topics/getting-started-launchpad-launch-booster.adoc
@@ -1,10 +1,10 @@
 [[launcher-launch-booster]]
-= Launch the Booster
+= Launching the Booster
 
 To launch your booster from the launch screen, you have the following options.
 
 [[launcher-launch-booster-cd]]
-== Launch Using Continuous Delivery
+== Launching Using Continuous Delivery
 
 To launch using continuous delivery, click the _Launch on OpenShift_ button.
 
@@ -35,7 +35,7 @@ Once your booster is deployed, you can then interact with its application or app
 NOTE: Each mission guide covers deploying as well as interacting with the booster. If you have already deployed your booster using the steps above, skip the _deployment section_ in the mission guide which covers the process for xref:launcher-launch-booster-manual[launching manually].
 
 [[launcher-launch-booster-manual]]
-== Launch Manually
+== Launching Manually
 
 To launch manually, click on _Download as Zip_.
 

--- a/docs/topics/getting-started-launchpad-launch-booster.adoc
+++ b/docs/topics/getting-started-launchpad-launch-booster.adoc
@@ -1,5 +1,5 @@
 [[launcher-launch-booster]]
-= Launch Your Booster
+= Launch the Booster
 
 To launch your booster from the launch screen, you have the following options.
 

--- a/docs/topics/getting-started-launchpad-launch-runtime-project-framework.adoc
+++ b/docs/topics/getting-started-launchpad-launch-runtime-project-framework.adoc
@@ -1,9 +1,9 @@
 [[launcher-launch-runtime-project-framework]]
-= Launch Your Runtime Project Framework
+= Launching Your Runtime Project Framework
 
 To launch your runtime project framework from the launch screen, you have the following options.
 
-== Launch Using Continuous Deployment
+== Launching Using Continuous Deployment
 
 To launch using continuous deployment, click the _Open in OpenShift_ button. This will:
 
@@ -13,4 +13,4 @@ To launch using continuous deployment, click the _Open in OpenShift_ button. Thi
  
 You can find a full list of runtime project frameworks in xref:available-runtime-project-frameworks[].
 
-== Launch Manually
+== Launching Manually

--- a/docs/topics/getting-started-launchpad-launch-runtime-project-framework.adoc
+++ b/docs/topics/getting-started-launchpad-launch-runtime-project-framework.adoc
@@ -1,5 +1,5 @@
 [[launcher-launch-runtime-project-framework]]
-= Launch Your Runtime Project Framework Project
+= Launch Your Runtime Project Framework
 
 To launch your runtime project framework from the launch screen, you have the following options.
 

--- a/docs/topics/getting-started-launchpad-update-booster-cd.adoc
+++ b/docs/topics/getting-started-launchpad-update-booster-cd.adoc
@@ -1,5 +1,5 @@
 [[update-cd]]
-= Update Using Continuous Delivery
+= Updating Using Continuous Delivery
 
 This approach allows you to deploy updates directly from the GitHub repository created by the {launcher}.
 

--- a/docs/topics/getting-started-launchpad-update-booster-manual.adoc
+++ b/docs/topics/getting-started-launchpad-update-booster-manual.adoc
@@ -1,4 +1,4 @@
-= Update Manually
+= Updating Manually
 
 This approach allows you to deploy updates directly from a local version of the GitHub repository created by {launcher}. 
 

--- a/docs/topics/getting-started-push-changes-osl.adoc
+++ b/docs/topics/getting-started-push-changes-osl.adoc
@@ -1,4 +1,4 @@
-= Push Changes to a {OpenShiftLocal}
+= Pushing Changes to a {OpenShiftLocal}
 
 Local development is a fine initial approach, but one of the big opportunities microservices presents is developing for the cloud _first_. This means pushing changes to the cloud and testing them as they are being developed. This can reduce problems that arise from "Well, it worked on my machine". 
 

--- a/docs/topics/getting-started-push-changes-oso.adoc
+++ b/docs/topics/getting-started-push-changes-oso.adoc
@@ -1,4 +1,4 @@
-= Push Changes to {OpenShiftOnline}
+= Pushing Changes to {OpenShiftOnline}
 
 You can also use the same process for pushing changes to a {OpenShiftLocal} with {OpenShiftOnline}.
 

--- a/docs/topics/getting-started-run-locally.adoc
+++ b/docs/topics/getting-started-run-locally.adoc
@@ -1,4 +1,4 @@
-= Run Locally 
+= Running Locally 
 
 . Navigate to link:{link-launcher-oso}[{launcher}] using your browser.
 . Select _Prepare for Takeoff_.

--- a/docs/topics/getting-started-ultrahook-setup.adoc
+++ b/docs/topics/getting-started-ultrahook-setup.adoc
@@ -1,5 +1,5 @@
 [[ultrahook-setup]]
-= Trigger Builds Automatically with UltraHook
+= Triggering Builds Automatically with UltraHook
 
 To configure your {OpenShiftLocal} to automatically trigger a build when a new commit is made to GitHub, we will use the UltraHook's proxy cloud application. This application exposes a public endpoint that GitHub will call when an event is issued, for example when a commit is pushed. If the UltraHook client is running on your local machine, then it will forward the HTTP request to an OpenShift Build Trigger endpoint in order to initiate the start of your booster's project build:
 

--- a/docs/topics/health-check-mission-basic-interaction-nodejs.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-nodejs.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {NodeJS} Booster
+= Interacting with the Unmodified {NodeJS} Booster
 
 Once you have the {NodeJS} booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
 

--- a/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {SpringBoot} Booster
+= Interacting with the Unmodified {SpringBoot} Booster
 
 Once you have the {SpringBoot} booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
 

--- a/docs/topics/health-check-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-vertx.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {VertX} Booster
+= Interacting with the Unmodified {VertX} Booster
 
 Once you have the {VertX} booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
 

--- a/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/health-check-mission-basic-interaction-wf-swarm.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {WildFlySwarm} Booster
+= Interacting with the Unmodified {WildFlySwarm} Booster
 
 Once you have the {WildFlySwarm} booster deployed, you will have a service called  `{app-name}` running that exposes a two REST endpoints: `/api/greeting` which returns a name as a String and `/api/killme`, which forces the service to become unresponsive as means to simulate a failure.
 

--- a/docs/topics/health-check-mission-deploy-booster.adoc
+++ b/docs/topics/health-check-mission-deploy-booster.adoc
@@ -1,5 +1,5 @@
 [[health_check_build_and_deploy_booster]]
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 

--- a/docs/topics/health-check-mission-deploy-booster.adoc
+++ b/docs/topics/health-check-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 [[health_check_build_and_deploy_booster]]
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 [[health_check_deploy-booster-osl-cli]]
-=== Deploy Using the `oc` CLI Client
+=== Deploying Using the `oc` CLI Client
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 

--- a/docs/topics/minishift-install-create-gh-personal-access-token.adoc
+++ b/docs/topics/minishift-install-create-gh-personal-access-token.adoc
@@ -1,4 +1,4 @@
-= Create a GitHub Personal Access Token
+= Creating a GitHub Personal Access Token
 
 IMPORTANT: You must have a link:http://github.com[GitHub] account to set up a personal access token. If you do not have one, you must link:http://github.com/join[create a GitHub account] before continuing.
 

--- a/docs/topics/minishift-install-nexus-setup.adoc
+++ b/docs/topics/minishift-install-nexus-setup.adoc
@@ -1,7 +1,7 @@
 // name variable defined locally, because it is only used in this topic
 :nexus-project-name: NEXUS_PROJECT_NAME
 
-= Using a Nexus Repository Server With the {launcher} Application on your {OpenShiftLocal}
+= Using a Nexus Repository Server With the {launcher} Application on a {OpenShiftLocal}
 
 While developing your cloud-native applications with Java and Maven you may be required to build them repeatedly.
 You can deploy a Nexus Repository server alongside the {launcher} application on your {OpenShiftLocal} and use it to fetch artifacts from the Maven Central Repository and cache them locally.

--- a/docs/topics/minishift-install-prereq.adoc
+++ b/docs/topics/minishift-install-prereq.adoc
@@ -3,7 +3,7 @@
 
 In order to use the {launcher} application on a local cloud, you must have a {OpenShiftLocal} installed and configured. You can use either {Minishift} `{MinishiftVersion}` or {CDK} `{CDKVersion}`.
 
-== Install {Minishift}
+== Installing {Minishift}
 The installation steps for {Minishift} are available link:https://docs.openshift.org/latest/minishift/getting-started/installing.html[in the OpenShift documentation] and vary by platform.
 
 . Verify you have {Minishift} installed and configured.
@@ -43,7 +43,7 @@ features: Basic-Auth GSSAPI Kerberos SPNEGO
 ----
 
 
-== Install {CDK}
+== Installing {CDK}
 
 The installation steps for {CDK} are available link:https://access.redhat.com/documentation/en-us/red_hat_container_development_kit/3.0/html-single/installation_guide/[in {CDK} Installation Guide] and vary by platform.
 

--- a/docs/topics/minishift-install-start-configure-minishift.adoc
+++ b/docs/topics/minishift-install-start-configure-minishift.adoc
@@ -1,5 +1,5 @@
 [[start-local-cloud]]
-= Start and Configure your {OpenShiftLocal} for the {launcher} Application
+= Start and Configure the {OpenShiftLocal} for the {launcher} Application
 
 NOTE: Starting your {OpenShiftLocal} may trigger a download of large virtual machines or Linux container images. This may take a while. Subsequent startups should be shorter as long as the virtual machines and Linux container images remained cached.
 

--- a/docs/topics/minishift-install-start-configure-minishift.adoc
+++ b/docs/topics/minishift-install-start-configure-minishift.adoc
@@ -1,5 +1,5 @@
 [[start-local-cloud]]
-= Start and Configure the {OpenShiftLocal} for the {launcher} Application
+= Starting and Configuring the {OpenShiftLocal} for the {launcher} Application
 
 NOTE: Starting your {OpenShiftLocal} may trigger a download of large virtual machines or Linux container images. This may take a while. Subsequent startups should be shorter as long as the virtual machines and Linux container images remained cached.
 

--- a/docs/topics/mission-deploy-booster.adoc
+++ b/docs/topics/mission-deploy-booster.adoc
@@ -1,6 +1,6 @@
 
 [[crud_build_and_deploy_booster]]
-= Prerequisite: Deploy Your Booster and Determine its Route
+= Prerequisite: Deploy the Booster and Determine Its Route
 
 Before proceeding, follow the instructions in the `README.md` to deploy your booster and determine its URL.
 

--- a/docs/topics/mission-deploy-booster.adoc
+++ b/docs/topics/mission-deploy-booster.adoc
@@ -1,6 +1,6 @@
 
 [[crud_build_and_deploy_booster]]
-= Prerequisite: Deploy the Booster and Determine Its Route
+= Prerequisite: Deploying the Booster and Determine Its Route
 
 Before proceeding, follow the instructions in the `README.md` to deploy your booster and determine its URL.
 

--- a/docs/topics/mission-secured-deploy-rhsso-cd.adoc
+++ b/docs/topics/mission-secured-deploy-rhsso-cd.adoc
@@ -1,7 +1,7 @@
 [[mission-secured-deploy-rhsso-cd]]
-= Deploy RH SSO to your {OpenShiftLocal} using your {launcher} Application
+= Deploy RH SSO to {OpenShiftLocal} using the {launcher} Application
 
-== Deploy the Secured Booster using your {launcher} Application
+== Deploy the Secured Booster using the {launcher} Application
 
 . Navigate to your {launcher} application running on your {OpenShiftLocal} and click _Prepare for Takeoff_.
 . Choose _Use OpenShift Online to build and deploy_.
@@ -31,7 +31,7 @@ NOTE: It may take a few minutes for the link to appear.
 You will be redirected to the startup logs in the `jenkins` pod. You have also given your {OpenShiftLocal} access to the `jenkins` pod and its logging information. Once you see the build start in the Jenkins logs, if you return to the _Overview_ page for your project in your {OpenShiftLocal}, you can see that the pipelines now show the build status.
 
 
-== Build your Secured Booster's Client
+== Build a client for the Secured Booster
 
 . Clone your project from GitHub.
 +

--- a/docs/topics/mission-secured-deploy-rhsso-cd.adoc
+++ b/docs/topics/mission-secured-deploy-rhsso-cd.adoc
@@ -1,7 +1,7 @@
 [[mission-secured-deploy-rhsso-cd]]
-= Deploy RH SSO to {OpenShiftLocal} using the {launcher} Application
+= Deploying RH SSO to {OpenShiftLocal} using the {launcher} Application
 
-== Deploy the Secured Booster using the {launcher} Application
+== Deploying the Secured Booster using the {launcher} Application
 
 . Navigate to your {launcher} application running on your {OpenShiftLocal} and click _Prepare for Takeoff_.
 . Choose _Use OpenShift Online to build and deploy_.
@@ -31,7 +31,7 @@ NOTE: It may take a few minutes for the link to appear.
 You will be redirected to the startup logs in the `jenkins` pod. You have also given your {OpenShiftLocal} access to the `jenkins` pod and its logging information. Once you see the build start in the Jenkins logs, if you return to the _Overview_ page for your project in your {OpenShiftLocal}, you can see that the pipelines now show the build status.
 
 
-== Build a client for the Secured Booster
+== Building a client for the Secured Booster
 
 . Clone your project from GitHub.
 +

--- a/docs/topics/mission-secured-deploy-rhsso-zip.adoc
+++ b/docs/topics/mission-secured-deploy-rhsso-zip.adoc
@@ -1,5 +1,5 @@
 [[mission-secured-deploy-rhsso-zip]]
-= Deploy Using the `oc` CLI Client
+= Deploying Using the `oc` CLI Client
 
 :sso-app-name: secure-sso
 :sso-auth-url: https://{sso-app-name}-MY_PROJECT_NAME.{osl-route-hostname}/auth

--- a/docs/topics/readme/circuit-breaker-README.adoc
+++ b/docs/topics/readme/circuit-breaker-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -27,7 +27,7 @@ $ ${OSORunCMD}
 ----
 
 
-== Interact with the Booster on a Single-node OpenShift Cluster
+== Interacting with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/circuit-breaker-README.adoc
+++ b/docs/topics/readme/circuit-breaker-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -27,7 +27,7 @@ $ ${OSORunCMD}
 ----
 
 
-== Interact with this Booster on a Single-node OpenShift Cluster
+== Interact with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/configmap-README.adoc
+++ b/docs/topics/readme/configmap-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run the Booster Locally
+== Running the Booster Locally
 To run this booster on your local host:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -18,7 +18,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with the Booster Locally
+== Interacting with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -30,7 +30,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -69,7 +69,7 @@ $ ${OSORunCMD}
 
 
 
-== Interact with the Booster on a Single-node OpenShift Cluster
+== Interacting with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/configmap-README.adoc
+++ b/docs/topics/readme/configmap-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run this Booster Locally
+== Run the Booster Locally
 To run this booster on your local host:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -18,7 +18,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with this Booster Locally
+== Interact with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -30,7 +30,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -69,7 +69,7 @@ $ ${OSORunCMD}
 
 
 
-== Interact with this Booster on a Single-node OpenShift Cluster
+== Interact with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/crud-README.adoc
+++ b/docs/topics/readme/crud-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -23,7 +23,7 @@ $ oc new-app -e POSTGRESQL_USER=luke -ePOSTGRESQL_PASSWORD=secret -ePOSTGRESQL_D
 $ ${OSORunCMD}
 ----
 
-== Interact with the Booster on a Single-node OpenShift Cluster
+== Interacting with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/crud-README.adoc
+++ b/docs/topics/readme/crud-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -23,7 +23,7 @@ $ oc new-app -e POSTGRESQL_USER=luke -ePOSTGRESQL_PASSWORD=secret -ePOSTGRESQL_D
 $ ${OSORunCMD}
 ----
 
-== Interact with this Booster on a Single-node OpenShift Cluster
+== Interact with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/health-check-README.adoc
+++ b/docs/topics/readme/health-check-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run this Booster Locally
+== Run the Booster Locally
 To run this booster on your local host:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -18,7 +18,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with this Booster Locally
+== Interact with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -30,7 +30,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -47,7 +47,7 @@ $ ${OSORunCMD}
 ----
 
 
-== Interact with this Booster on a Single-node OpenShift Cluster
+== Interact with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/health-check-README.adoc
+++ b/docs/topics/readme/health-check-README.adoc
@@ -6,7 +6,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run the Booster Locally
+== Running the Booster Locally
 To run this booster on your local host:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -18,7 +18,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with the Booster Locally
+== Interacting with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 
 [source,bash,options="nowrap",subs="attributes+"]
@@ -30,7 +30,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
@@ -47,7 +47,7 @@ $ ${OSORunCMD}
 ----
 
 
-== Interact with the Booster on a Single-node OpenShift Cluster
+== Interacting with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain it's URL:
 

--- a/docs/topics/readme/osio-circuit-breaker-README.adoc
+++ b/docs/topics/readme/osio-circuit-breaker-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-circuit-breaker-README.adoc
+++ b/docs/topics/readme/osio-circuit-breaker-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/osio-configmap-README.adoc
+++ b/docs/topics/readme/osio-configmap-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-configmap-README.adoc
+++ b/docs/topics/readme/osio-configmap-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/osio-crud-README.adoc
+++ b/docs/topics/readme/osio-crud-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-crud-README.adoc
+++ b/docs/topics/readme/osio-crud-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/osio-health-check-README.adoc
+++ b/docs/topics/readme/osio-health-check-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-health-check-README.adoc
+++ b/docs/topics/readme/osio-health-check-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/osio-rest-http-README.adoc
+++ b/docs/topics/readme/osio-rest-http-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-rest-http-README.adoc
+++ b/docs/topics/readme/osio-rest-http-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/osio-rest-http-secured-README.adoc
+++ b/docs/topics/readme/osio-rest-http-secured-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with your Booster in Stage
+== Interact with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote your Booster to Run
+== Promote the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit your Booster
+== Edit the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.

--- a/docs/topics/readme/osio-rest-http-secured-README.adoc
+++ b/docs/topics/readme/osio-rest-http-secured-README.adoc
@@ -1,19 +1,19 @@
 = ${mission} - ${runtime} Booster
 
-== Interact with the Booster in Stage
+== Interacting with the Booster in Stage
 From your workspace, click _Stage - 1.0.1_ under _Applications_. This will open the stage version of your booster that you can interact with. For more details on interacting with this booster, see the link:${guideURL}[${runtime} Runtime Guide].
 
 NOTE: Deploying your booster to Stage may take a few minutes to complete.
 
 
-== Promote the Booster to Run
+== Promoting the Booster to Run
 * From your workspace, click _${targetRepository}_ under _Pipelines_
 * Click _Input Required_ under _Approve_
 * Click _Promote_.
 * Click the blue link next to _Rollout to Run_.
 * Return to your workspace and click _Run - 1.0.1_ under _Applications_ to interact with the _Run_ version of this booster.
 
-== Edit the Booster
+== Editing the Booster
 * Click _Create_ at the top of the page.
 * Click _Create Workspace_.
 * Click _Open_.
@@ -23,7 +23,7 @@ NOTE: This will create a popup window so you may have to enable popups in your b
 * Make a change to your booster (e.g. edit `${fileLocation}`).
 * Click the _Run_ button (the triangle in the top next to the _Debug_ button) and choose _Run_ to build and deploy your booster in a temporary Che environment. Use the _Preview_ URL at the top of the log window. Observe that your changes appear.
 
-== Promote the Changes
+== Promoting the Changes
 * Click _Git_ -> _Add to Index_ to stage your change.
 * Click _Git_ -> _Commit_ to commit your change. Ensure _Push to Origin_ is checked before clicking _Commit_.
 * Return to your workspace and observe a new pipeline has started. Once complete click on _Stage - 1.0.2_ under _Applications_ and observe your changes.

--- a/docs/topics/readme/rest-http-README.adoc
+++ b/docs/topics/readme/rest-http-README.adoc
@@ -4,7 +4,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run the Booster Locally
+== Runing the Booster Locally
 
 To run this booster on your local host:
 
@@ -17,7 +17,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with the Booster Locally
+== Interacting with the Booster Locally
 
 To interact with your booster while it's running locally, use the form at `http://localhost:8080` or the `curl` command:
 
@@ -31,7 +31,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 ----
 
 
-== Update the Booster
+== Updating the Booster
 To update your booster:
 
 . Stop your booster.
@@ -43,7 +43,7 @@ NOTE: To stop your running booster in a Linux or macOS terminal, use `CTRL+C`. I
 . Confirm your change appears.
 
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:

--- a/docs/topics/readme/rest-http-README.adoc
+++ b/docs/topics/readme/rest-http-README.adoc
@@ -4,7 +4,7 @@ ${prerequisite}
 
 ${cicdSection}
 
-== Run this Booster Locally
+== Run the Booster Locally
 
 To run this booster on your local host:
 
@@ -17,7 +17,7 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
-== Interact with this Booster Locally
+== Interact with the Booster Locally
 
 To interact with your booster while it's running locally, use the form at `http://localhost:8080` or the `curl` command:
 
@@ -31,7 +31,7 @@ $ curl http://localhost:8080/api/greeting?name=Sarah
 ----
 
 
-== Update this Booster
+== Update the Booster
 To update your booster:
 
 . Stop your booster.
@@ -43,7 +43,7 @@ NOTE: To stop your running booster in a Linux or macOS terminal, use `CTRL+C`. I
 . Confirm your change appears.
 
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:

--- a/docs/topics/readme/rest-http-secured-README.adoc
+++ b/docs/topics/readme/rest-http-secured-README.adoc
@@ -4,7 +4,7 @@ IMPORTANT: This booster requires that you use link:https://access.redhat.com/pro
 
 ${prerequisite}
 
-== Run this Booster on a Single-node OpenShift Cluster
+== Run the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 IMPORTANT: You *MUST* link:${missionURL}[update the configuration of your single-node OpenShift cluster as detailed in the mission documentation] before you can deploy this mission. 
@@ -40,7 +40,7 @@ $ cd ..
 
 
 
-== Interact with this Booster on a Single-node OpenShift Cluster
+== Interact with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain the name of the application and it's URL:
 

--- a/docs/topics/readme/rest-http-secured-README.adoc
+++ b/docs/topics/readme/rest-http-secured-README.adoc
@@ -4,7 +4,7 @@ IMPORTANT: This booster requires that you use link:https://access.redhat.com/pro
 
 ${prerequisite}
 
-== Run the Booster on a Single-node OpenShift Cluster
+== Running the Booster on a Single-node OpenShift Cluster
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 IMPORTANT: You *MUST* link:${missionURL}[update the configuration of your single-node OpenShift cluster as detailed in the mission documentation] before you can deploy this mission. 
@@ -40,7 +40,7 @@ $ cd ..
 
 
 
-== Interact with the Booster on a Single-node OpenShift Cluster
+== Interacting with the Booster on a Single-node OpenShift Cluster
 
 To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain the name of the application and it's URL:
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-nodejs.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-nodejs.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {NodeJS} Booster
+= Interacting with the Unmodified {NodeJS} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-spring-boot-tomcat.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {SpringBoot} Booster
+= Interacting with the Unmodified {SpringBoot} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-vertx.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-vertx.adoc
@@ -1,5 +1,5 @@
 [[interact]]
-= Interact with the Unmodified {VertX} Booster
+= Interacting with the Unmodified {VertX} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/rest-level-0-mission-basic-interaction-wf-swarm.adoc
+++ b/docs/topics/rest-level-0-mission-basic-interaction-wf-swarm.adoc
@@ -1,4 +1,4 @@
-= Interact with the Unmodified {WildFlySwarm} Booster
+= Interacting with the Unmodified {WildFlySwarm} Booster
 
 The booster provides a default HTTP endpoint that accepts GET requests.
 

--- a/docs/topics/rest-level-0-mission-deploy-booster.adoc
+++ b/docs/topics/rest-level-0-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 [[rest_build_and_deploy_booster]]
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 
 // this is intentionally a level 3
-=== Deploy Using the `oc` CLI Client
+=== Deploying Using the `oc` CLI Client
 
 include::oc-client-deploy-booster-download-note.adoc[leveloffset=+3]
 

--- a/docs/topics/rest-level-0-mission-deploy-booster.adoc
+++ b/docs/topics/rest-level-0-mission-deploy-booster.adoc
@@ -1,5 +1,5 @@
 [[rest_build_and_deploy_booster]]
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
 include::booster-deploy-openshift-local.adoc[leveloffset=+1]
 

--- a/docs/topics/secured-booster-minishift.adoc
+++ b/docs/topics/secured-booster-minishift.adoc
@@ -1,4 +1,4 @@
-= Configure Your {OpenShiftLocal}
+= Configuring Your {OpenShiftLocal}
 
 You can use your {OpenShiftLocal} to run your secured booster, but you need to update it from the default configuration.
 

--- a/docs/topics/secured-mission-common-interaction.adoc
+++ b/docs/topics/secured-mission-common-interaction.adoc
@@ -1,4 +1,4 @@
-= Interact with the Secured Booster
+= Interacting with the Secured Booster
 
 The Secured booster provides a default HTTP endpoint that accepts `GET` requests if the caller is authenticated and authorized. The `sso` directory of the booster contains a Java client you can use to interact with the Secured booster. The client first authenticates against the {RHSSO} server and then performs a `GET` request against the Secured booster using the access token returned by the authentication step.
 

--- a/docs/topics/secured-mission-deploy-booster.adoc
+++ b/docs/topics/secured-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 
 
-= Build and Deploy the Booster
+= Building and Deploying the Booster
 
-== Deploy the Booster to a {OpenShiftLocal}
+== Deploying the Booster to a {OpenShiftLocal}
 
-=== Deploy the Secured Booster using the {launcher} Application
+=== Deploying the Secured Booster using the {launcher} Application
 
 . Navigate to your {launcher} application running on your {OpenShiftLocal} and use it to create and launch your booster.
 

--- a/docs/topics/secured-mission-deploy-booster.adoc
+++ b/docs/topics/secured-mission-deploy-booster.adoc
@@ -1,10 +1,10 @@
 
 
-= Build and Deploy Your Booster
+= Build and Deploy the Booster
 
-== Deploy your Booster to a {OpenShiftLocal}
+== Deploy the Booster to a {OpenShiftLocal}
 
-=== Deploy the Secured Booster using your {launcher} Application
+=== Deploy the Secured Booster using the {launcher} Application
 
 . Navigate to your {launcher} application running on your {OpenShiftLocal} and use it to create and launch your booster.
 

--- a/docs/topics/secured-spring-boot-clone-booster.adoc
+++ b/docs/topics/secured-spring-boot-clone-booster.adoc
@@ -1,4 +1,4 @@
-= Clone the {SpringBoot} Secured Booster
+= Cloning the {SpringBoot} Secured Booster
 
 You need to clone the secured booster, which includes a submodule for the {RHSSO} portion of the booster.
 

--- a/docs/topics/secured-vertx-clone-booster.adoc
+++ b/docs/topics/secured-vertx-clone-booster.adoc
@@ -1,4 +1,4 @@
-= Clone the {VertX} Secured Booster
+= Cloning the {VertX} Secured Booster
 
 You need to clone the secured booster, which includes a submodule for the {RHSSO} portion of the booster.
 

--- a/docs/topics/secured-wf-swarm-clone-booster.adoc
+++ b/docs/topics/secured-wf-swarm-clone-booster.adoc
@@ -1,4 +1,4 @@
-= Clone the {WildFlySwarm} Secured Booster
+= Cloning the {WildFlySwarm} Secured Booster
 
 You need to clone the secured booster, which includes a submodule for the {RHSSO} portion of the booster.
 


### PR DESCRIPTION
Performed the following fixes in headings:

* Uppercasing/lowercasing as necessary [Chicago Manual of Style]
* Replaced "your" and "this" with "the" [Minimalism]
* Converted imperatives to gerunds [RH Stylepedia]

I am fairly sure I did not break any xrefs, but I think we should create explicit IDs for all headings anyway. However, that's definitely out of the scope of #647.

Resolves #647.