### PR TITLE
Storing XML schema locally for improved performance

### DIFF
--- a/scripts/xml-schema/docbook.xsd
+++ b/scripts/xml-schema/docbook.xsd
@@ -1,0 +1,17458 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:docbook="http://docbook.org/ns/docbook">
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:attributeGroup name="db.common.attributes">
+    <xs:attribute ref="xml:id"/>
+    <xs:attribute name="version"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute name="remap"/>
+    <xs:attribute name="xreflabel"/>
+    <xs:attribute name="revisionflag">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="changed"/>
+          <xs:enumeration value="added"/>
+          <xs:enumeration value="deleted"/>
+          <xs:enumeration value="off"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="ltr"/>
+          <xs:enumeration value="rtl"/>
+          <xs:enumeration value="lro"/>
+          <xs:enumeration value="rlo"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="arch"/>
+    <xs:attribute name="audience"/>
+    <xs:attribute name="condition"/>
+    <xs:attribute name="conformance"/>
+    <xs:attribute name="os"/>
+    <xs:attribute name="revision"/>
+    <xs:attribute name="security"/>
+    <xs:attribute name="userlevel"/>
+    <xs:attribute name="vendor"/>
+    <xs:attribute name="wordsize"/>
+    <xs:attribute name="annotations"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="db.common.linking.attributes">
+    <xs:attribute name="linkend" type="xs:IDREF"/>
+    <xs:attribute ref="xlink:href"/>
+    <xs:attribute ref="xlink:type"/>
+    <xs:attribute ref="xlink:role"/>
+    <xs:attribute ref="xlink:arcrole"/>
+    <xs:attribute ref="xlink:title"/>
+    <xs:attribute ref="xlink:show"/>
+    <xs:attribute ref="xlink:actuate"/>
+  </xs:attributeGroup>
+  <xs:element name="title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="titleabbrev">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subtitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="info">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:title"/>
+          <xs:element ref="docbook:titleabbrev"/>
+          <xs:element ref="docbook:subtitle"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:abstract"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:artpagenums"/>
+          <xs:element ref="docbook:author"/>
+          <xs:element ref="docbook:authorgroup"/>
+          <xs:element ref="docbook:authorinitials"/>
+          <xs:element ref="docbook:bibliocoverage"/>
+          <xs:element ref="docbook:biblioid"/>
+          <xs:element ref="docbook:bibliosource"/>
+          <xs:element ref="docbook:collab"/>
+          <xs:element ref="docbook:confgroup"/>
+          <xs:element ref="docbook:contractsponsor"/>
+          <xs:element ref="docbook:contractnum"/>
+          <xs:element ref="docbook:copyright"/>
+          <xs:element ref="docbook:cover"/>
+          <xs:element ref="docbook:date"/>
+          <xs:element ref="docbook:edition"/>
+          <xs:element ref="docbook:editor"/>
+          <xs:element ref="docbook:issuenum"/>
+          <xs:element ref="docbook:keywordset"/>
+          <xs:element ref="docbook:legalnotice"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:org"/>
+          <xs:element ref="docbook:orgname"/>
+          <xs:element ref="docbook:othercredit"/>
+          <xs:element ref="docbook:pagenums"/>
+          <xs:element ref="docbook:printhistory"/>
+          <xs:element ref="docbook:pubdate"/>
+          <xs:element ref="docbook:publisher"/>
+          <xs:element ref="docbook:publishername"/>
+          <xs:element ref="docbook:releaseinfo"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:seriesvolnums"/>
+          <xs:element ref="docbook:subjectset"/>
+          <xs:element ref="docbook:volumenum"/>
+          <xs:element ref="docbook:annotation"/>
+          <xs:element ref="docbook:extendedlink"/>
+          <xs:element ref="docbook:bibliomisc"/>
+          <xs:element ref="docbook:bibliomset"/>
+          <xs:element ref="docbook:bibliorelation"/>
+          <xs:element ref="docbook:biblioset"/>
+          <xs:element ref="docbook:itermset"/>
+          <xs:element ref="docbook:productname"/>
+          <xs:element ref="docbook:productnumber"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subjectset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:subject"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="scheme" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:subjectterm"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="weight"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subjectterm">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keywordset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:keyword"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keyword">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="procedure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:step"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="step">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:sequence minOccurs="0">
+              <xs:choice>
+                <xs:element ref="docbook:substeps"/>
+                <xs:element ref="docbook:stepalternatives"/>
+              </xs:choice>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="docbook:itemizedlist"/>
+                <xs:element ref="docbook:orderedlist"/>
+                <xs:element ref="docbook:procedure"/>
+                <xs:element ref="docbook:simplelist"/>
+                <xs:element ref="docbook:variablelist"/>
+                <xs:element ref="docbook:segmentedlist"/>
+                <xs:element ref="docbook:glosslist"/>
+                <xs:element ref="docbook:bibliolist"/>
+                <xs:element ref="docbook:calloutlist"/>
+                <xs:element ref="docbook:qandaset"/>
+                <xs:element ref="docbook:example"/>
+                <xs:element ref="docbook:figure"/>
+                <xs:element ref="docbook:table"/>
+                <xs:element ref="docbook:equation"/>
+                <xs:element ref="docbook:informalexample"/>
+                <xs:element ref="docbook:informalfigure"/>
+                <xs:element ref="docbook:informaltable"/>
+                <xs:element ref="docbook:informalequation"/>
+                <xs:element ref="docbook:sidebar"/>
+                <xs:element ref="docbook:blockquote"/>
+                <xs:element ref="docbook:address"/>
+                <xs:element ref="docbook:epigraph"/>
+                <xs:element ref="docbook:mediaobject"/>
+                <xs:element ref="docbook:screenshot"/>
+                <xs:element ref="docbook:task"/>
+                <xs:element ref="docbook:productionset"/>
+                <xs:element ref="docbook:constraintdef"/>
+                <xs:element ref="docbook:msgset"/>
+                <xs:element ref="docbook:screen"/>
+                <xs:element ref="docbook:literallayout"/>
+                <xs:element ref="docbook:programlistingco"/>
+                <xs:element ref="docbook:screenco"/>
+                <xs:element ref="docbook:programlisting"/>
+                <xs:element ref="docbook:synopsis"/>
+                <xs:element ref="docbook:bridgehead"/>
+                <xs:element ref="docbook:remark"/>
+                <xs:element ref="docbook:revhistory"/>
+                <xs:element ref="docbook:indexterm"/>
+                <xs:element ref="docbook:funcsynopsis"/>
+                <xs:element ref="docbook:classsynopsis"/>
+                <xs:element ref="docbook:methodsynopsis"/>
+                <xs:element ref="docbook:constructorsynopsis"/>
+                <xs:element ref="docbook:destructorsynopsis"/>
+                <xs:element ref="docbook:fieldsynopsis"/>
+                <xs:element ref="docbook:cmdsynopsis"/>
+                <xs:element ref="docbook:caution"/>
+                <xs:element ref="docbook:important"/>
+                <xs:element ref="docbook:note"/>
+                <xs:element ref="docbook:tip"/>
+                <xs:element ref="docbook:warning"/>
+                <xs:element ref="docbook:anchor"/>
+                <xs:element ref="docbook:para"/>
+                <xs:element ref="docbook:formalpara"/>
+                <xs:element ref="docbook:simpara"/>
+                <xs:element ref="docbook:annotation"/>
+              </xs:choice>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:choice>
+              <xs:element ref="docbook:substeps"/>
+              <xs:element ref="docbook:stepalternatives"/>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="performance">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="optional"/>
+            <xs:enumeration value="required"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="stepalternatives">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:step"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="performance">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="optional"/>
+            <xs:enumeration value="required"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="substeps">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:step"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="performance">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="optional"/>
+            <xs:enumeration value="required"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sidebar">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abstract">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="personblurb">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="blockquote">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:attribution"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="attribution">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bridgehead">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="renderas">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sect1"/>
+            <xs:enumeration value="sect2"/>
+            <xs:enumeration value="sect3"/>
+            <xs:enumeration value="sect4"/>
+            <xs:enumeration value="sect5"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherrenderas" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="remark">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="epigraph">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element minOccurs="0" ref="docbook:attribution"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:literallayout"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="footnote">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="formalpara">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+        <xs:element ref="docbook:para"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="para">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="simpara">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="itemizedlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:listitem"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="spacing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+            <xs:enumeration value="normal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mark" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="orderedlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:listitem"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="spacing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+            <xs:enumeration value="normal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startingnumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="inheritnum">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ignore"/>
+            <xs:enumeration value="inherit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="numeration">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="arabic"/>
+            <xs:enumeration value="upperalpha"/>
+            <xs:enumeration value="loweralpha"/>
+            <xs:enumeration value="upperroman"/>
+            <xs:enumeration value="lowerroman"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="listitem">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="override" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="segmentedlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:segtitle"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:seglistitem"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="segtitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seglistitem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:seg"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seg">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="simplelist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:member"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="type" default="vert">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="horiz"/>
+            <xs:enumeration value="vert"/>
+            <xs:enumeration value="inline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columns" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="member">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="variablelist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:varlistentry"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="spacing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+            <xs:enumeration value="normal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="termlength"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="varlistentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:term"/>
+        <xs:element ref="docbook:listitem"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="term">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="example">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="floatstyle"/>
+      <xs:attribute name="width" type="xs:NMTOKEN"/>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="informalexample">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="floatstyle"/>
+      <xs:attribute name="width" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="literallayout">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="monospaced"/>
+            <xs:enumeration value="normal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="screen">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+      <xs:attribute name="width" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="screenshot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:mediaobject"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="figure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="floatstyle"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="informalfigure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="floatstyle"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mediaobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:videoobject"/>
+          <xs:element ref="docbook:audioobject"/>
+          <xs:element ref="docbook:imageobject"/>
+          <xs:element ref="docbook:textobject"/>
+          <xs:element ref="docbook:imageobjectco"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inlinemediaobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:videoobject"/>
+          <xs:element ref="docbook:audioobject"/>
+          <xs:element ref="docbook:imageobject"/>
+          <xs:element ref="docbook:textobject"/>
+          <xs:element ref="docbook:imageobjectco"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="videoobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:videodata"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="audioobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:audiodata"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="imageobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:imagedata"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="textobject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice>
+          <xs:element ref="docbook:phrase"/>
+          <xs:element ref="docbook:textdata"/>
+          <xs:choice maxOccurs="unbounded">
+            <xs:element ref="docbook:itemizedlist"/>
+            <xs:element ref="docbook:orderedlist"/>
+            <xs:element ref="docbook:procedure"/>
+            <xs:element ref="docbook:simplelist"/>
+            <xs:element ref="docbook:variablelist"/>
+            <xs:element ref="docbook:segmentedlist"/>
+            <xs:element ref="docbook:glosslist"/>
+            <xs:element ref="docbook:bibliolist"/>
+            <xs:element ref="docbook:calloutlist"/>
+            <xs:element ref="docbook:qandaset"/>
+            <xs:element ref="docbook:example"/>
+            <xs:element ref="docbook:figure"/>
+            <xs:element ref="docbook:table"/>
+            <xs:element ref="docbook:equation"/>
+            <xs:element ref="docbook:informalexample"/>
+            <xs:element ref="docbook:informalfigure"/>
+            <xs:element ref="docbook:informaltable"/>
+            <xs:element ref="docbook:informalequation"/>
+            <xs:element ref="docbook:sidebar"/>
+            <xs:element ref="docbook:blockquote"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:epigraph"/>
+            <xs:element ref="docbook:mediaobject"/>
+            <xs:element ref="docbook:screenshot"/>
+            <xs:element ref="docbook:task"/>
+            <xs:element ref="docbook:productionset"/>
+            <xs:element ref="docbook:constraintdef"/>
+            <xs:element ref="docbook:msgset"/>
+            <xs:element ref="docbook:screen"/>
+            <xs:element ref="docbook:literallayout"/>
+            <xs:element ref="docbook:programlistingco"/>
+            <xs:element ref="docbook:screenco"/>
+            <xs:element ref="docbook:programlisting"/>
+            <xs:element ref="docbook:synopsis"/>
+            <xs:element ref="docbook:bridgehead"/>
+            <xs:element ref="docbook:remark"/>
+            <xs:element ref="docbook:revhistory"/>
+            <xs:element ref="docbook:indexterm"/>
+            <xs:element ref="docbook:funcsynopsis"/>
+            <xs:element ref="docbook:classsynopsis"/>
+            <xs:element ref="docbook:methodsynopsis"/>
+            <xs:element ref="docbook:constructorsynopsis"/>
+            <xs:element ref="docbook:destructorsynopsis"/>
+            <xs:element ref="docbook:fieldsynopsis"/>
+            <xs:element ref="docbook:cmdsynopsis"/>
+            <xs:element ref="docbook:caution"/>
+            <xs:element ref="docbook:important"/>
+            <xs:element ref="docbook:note"/>
+            <xs:element ref="docbook:tip"/>
+            <xs:element ref="docbook:warning"/>
+            <xs:element ref="docbook:anchor"/>
+            <xs:element ref="docbook:para"/>
+            <xs:element ref="docbook:formalpara"/>
+            <xs:element ref="docbook:simpara"/>
+            <xs:element ref="docbook:annotation"/>
+          </xs:choice>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="videodata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="format"/>
+      <xs:attribute name="fileref"/>
+      <xs:attribute name="entityref" type="xs:ENTITY"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width"/>
+      <xs:attribute name="contentwidth"/>
+      <xs:attribute name="scalefit">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scale" type="xs:NMTOKEN"/>
+      <xs:attribute name="depth"/>
+      <xs:attribute name="contentdepth"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="audiodata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="format"/>
+      <xs:attribute name="fileref"/>
+      <xs:attribute name="entityref" type="xs:ENTITY"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="imagedata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="format"/>
+      <xs:attribute name="fileref"/>
+      <xs:attribute name="entityref" type="xs:ENTITY"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width"/>
+      <xs:attribute name="contentwidth"/>
+      <xs:attribute name="scalefit">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scale" type="xs:NMTOKEN"/>
+      <xs:attribute name="depth"/>
+      <xs:attribute name="contentdepth"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="textdata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="format"/>
+      <xs:attribute name="fileref"/>
+      <xs:attribute name="entityref" type="xs:ENTITY"/>
+      <xs:attribute name="encoding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="caption">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="address">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:pob"/>
+        <xs:element ref="docbook:street"/>
+        <xs:element ref="docbook:city"/>
+        <xs:element ref="docbook:state"/>
+        <xs:element ref="docbook:postcode"/>
+        <xs:element ref="docbook:country"/>
+        <xs:element ref="docbook:phone"/>
+        <xs:element ref="docbook:fax"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:otheraddr"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="street">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pob">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="postcode">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="city">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="state">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="country">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="phone">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fax">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="otheraddr">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="affiliation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:shortaffil"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:jobtitle"/>
+        <xs:choice>
+          <xs:element minOccurs="0" ref="docbook:org"/>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="docbook:orgname"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:orgdiv"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:address"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="shortaffil">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="jobtitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="orgname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="consortium"/>
+            <xs:enumeration value="corporation"/>
+            <xs:enumeration value="informal"/>
+            <xs:enumeration value="nonprofit"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="orgdiv">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="artpagenums">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="personname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:honorific"/>
+        <xs:element ref="docbook:firstname"/>
+        <xs:element ref="docbook:surname"/>
+        <xs:element ref="docbook:lineage"/>
+        <xs:element ref="docbook:othername"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element ref="docbook:personname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:personblurb"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element ref="docbook:orgname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:orgdiv"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="authorgroup">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:othercredit"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="collab">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:person"/>
+          <xs:element ref="docbook:personname"/>
+          <xs:element ref="docbook:org"/>
+          <xs:element ref="docbook:orgname"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:affiliation"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="authorinitials">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="person">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:personname"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:affiliation"/>
+          <xs:element ref="docbook:email"/>
+          <xs:element ref="docbook:uri"/>
+          <xs:element ref="docbook:personblurb"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="org">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:orgname"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:affiliation"/>
+          <xs:element ref="docbook:email"/>
+          <xs:element ref="docbook:uri"/>
+          <xs:element ref="docbook:orgdiv"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="confgroup">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:confdates"/>
+        <xs:element ref="docbook:conftitle"/>
+        <xs:element ref="docbook:confnum"/>
+        <xs:element ref="docbook:confsponsor"/>
+        <xs:element ref="docbook:address"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="confdates">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conftitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="confnum">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="confsponsor">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contractnum">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contractsponsor">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="copyright">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:year"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:holder"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="year">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="holder">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cover">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="date">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="edition">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="editor">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element ref="docbook:personname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:personblurb"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element ref="docbook:orgname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:orgdiv"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="biblioid">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="isrn"/>
+            <xs:enumeration value="issn"/>
+            <xs:enumeration value="libraryofcongress"/>
+            <xs:enumeration value="pubsnumber"/>
+            <xs:enumeration value="uri"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="citebiblioid">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="isrn"/>
+            <xs:enumeration value="issn"/>
+            <xs:enumeration value="libraryofcongress"/>
+            <xs:enumeration value="pubsnumber"/>
+            <xs:enumeration value="uri"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliosource">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="isrn"/>
+            <xs:enumeration value="issn"/>
+            <xs:enumeration value="libraryofcongress"/>
+            <xs:enumeration value="pubsnumber"/>
+            <xs:enumeration value="uri"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliorelation">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="isrn"/>
+            <xs:enumeration value="issn"/>
+            <xs:enumeration value="libraryofcongress"/>
+            <xs:enumeration value="pubsnumber"/>
+            <xs:enumeration value="uri"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass" type="xs:NMTOKEN"/>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="hasformat"/>
+            <xs:enumeration value="haspart"/>
+            <xs:enumeration value="hasversion"/>
+            <xs:enumeration value="isformatof"/>
+            <xs:enumeration value="ispartof"/>
+            <xs:enumeration value="isreferencedby"/>
+            <xs:enumeration value="isreplacedby"/>
+            <xs:enumeration value="isrequiredby"/>
+            <xs:enumeration value="isversionof"/>
+            <xs:enumeration value="references"/>
+            <xs:enumeration value="replaces"/>
+            <xs:enumeration value="requires"/>
+            <xs:enumeration value="othertype"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="othertype" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliocoverage">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="spatial">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="dcmipoint"/>
+            <xs:enumeration value="iso3166"/>
+            <xs:enumeration value="dcmibox"/>
+            <xs:enumeration value="tgn"/>
+            <xs:enumeration value="otherspatial"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherspatial" type="xs:NMTOKEN"/>
+      <xs:attribute name="temporal">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="dcmiperiod"/>
+            <xs:enumeration value="w3c-dtf"/>
+            <xs:enumeration value="othertemporal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="othertemporal" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="legalnotice">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="othercredit">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element ref="docbook:personname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:personblurb"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element ref="docbook:orgname"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:orgdiv"/>
+            <xs:element ref="docbook:affiliation"/>
+            <xs:element ref="docbook:email"/>
+            <xs:element ref="docbook:uri"/>
+            <xs:element ref="docbook:address"/>
+            <xs:element ref="docbook:contrib"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="copyeditor"/>
+            <xs:enumeration value="graphicdesigner"/>
+            <xs:enumeration value="other"/>
+            <xs:enumeration value="productioneditor"/>
+            <xs:enumeration value="technicaleditor"/>
+            <xs:enumeration value="translator"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pagenums">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contrib">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="honorific">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="firstname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="surname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lineage">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="othername">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="printhistory">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pubdate">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publisher">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:publishername"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:address"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publishername">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="releaseinfo">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revhistory">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:revision"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revision">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:revnumber"/>
+        <xs:element ref="docbook:date"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:authorinitials"/>
+          <xs:element ref="docbook:author"/>
+        </xs:choice>
+        <xs:choice minOccurs="0">
+          <xs:element ref="docbook:revremark"/>
+          <xs:element ref="docbook:revdescription"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revnumber">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revremark">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="revdescription">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seriesvolnums">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="volumenum">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issuenum">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="package">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="email">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lineannotation">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="parameter">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="command"/>
+            <xs:enumeration value="function"/>
+            <xs:enumeration value="option"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="replaceable">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="command"/>
+            <xs:enumeration value="function"/>
+            <xs:enumeration value="option"/>
+            <xs:enumeration value="parameter"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uri">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abbrev">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:trademark"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="acronym">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:trademark"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="citation">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="citerefentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:refentrytitle"/>
+        <xs:element minOccurs="0" ref="docbook:manvolnum"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refentrytitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="manvolnum">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="citetitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="pubwork">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="article"/>
+            <xs:enumeration value="bbs"/>
+            <xs:enumeration value="book"/>
+            <xs:enumeration value="cdrom"/>
+            <xs:enumeration value="chapter"/>
+            <xs:enumeration value="dvd"/>
+            <xs:enumeration value="emailmessage"/>
+            <xs:enumeration value="gopher"/>
+            <xs:enumeration value="journal"/>
+            <xs:enumeration value="manuscript"/>
+            <xs:enumeration value="newsposting"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="refentry"/>
+            <xs:enumeration value="section"/>
+            <xs:enumeration value="series"/>
+            <xs:enumeration value="set"/>
+            <xs:enumeration value="webpage"/>
+            <xs:enumeration value="wiki"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="emphasis">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="foreignphrase">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="phrase">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="quote">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subscript">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="superscript">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trademark">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="copyright"/>
+            <xs:enumeration value="registered"/>
+            <xs:enumeration value="service"/>
+            <xs:enumeration value="trade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="wordasword">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="footnoteref">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="xref">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="xrefstyle"/>
+      <xs:attribute name="endterm" type="xs:IDREF"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="link">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="xrefstyle"/>
+      <xs:attribute name="endterm" type="xs:IDREF"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="olink">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="targetdoc"/>
+      <xs:attribute name="role"/>
+      <xs:attribute name="xrefstyle"/>
+      <xs:attribute name="localinfo"/>
+      <xs:attribute name="targetptr"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="anchor">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="alt">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:inlinemediaobject"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="set">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:toc"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:set"/>
+          <xs:element ref="docbook:book"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:setindex"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="book">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+          <xs:element ref="docbook:dedication"/>
+          <xs:element ref="docbook:acknowledgements"/>
+          <xs:element ref="docbook:preface"/>
+          <xs:element ref="docbook:chapter"/>
+          <xs:element ref="docbook:appendix"/>
+          <xs:element ref="docbook:article"/>
+          <xs:element ref="docbook:colophon"/>
+          <xs:element ref="docbook:part"/>
+          <xs:element ref="docbook:reference"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="dedication">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="acknowledgements">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="colophon">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="appendix">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+          <xs:choice>
+            <xs:sequence>
+              <xs:choice maxOccurs="unbounded">
+                <xs:element ref="docbook:itemizedlist"/>
+                <xs:element ref="docbook:orderedlist"/>
+                <xs:element ref="docbook:procedure"/>
+                <xs:element ref="docbook:simplelist"/>
+                <xs:element ref="docbook:variablelist"/>
+                <xs:element ref="docbook:segmentedlist"/>
+                <xs:element ref="docbook:glosslist"/>
+                <xs:element ref="docbook:bibliolist"/>
+                <xs:element ref="docbook:calloutlist"/>
+                <xs:element ref="docbook:qandaset"/>
+                <xs:element ref="docbook:example"/>
+                <xs:element ref="docbook:figure"/>
+                <xs:element ref="docbook:table"/>
+                <xs:element ref="docbook:equation"/>
+                <xs:element ref="docbook:informalexample"/>
+                <xs:element ref="docbook:informalfigure"/>
+                <xs:element ref="docbook:informaltable"/>
+                <xs:element ref="docbook:informalequation"/>
+                <xs:element ref="docbook:sidebar"/>
+                <xs:element ref="docbook:blockquote"/>
+                <xs:element ref="docbook:address"/>
+                <xs:element ref="docbook:epigraph"/>
+                <xs:element ref="docbook:mediaobject"/>
+                <xs:element ref="docbook:screenshot"/>
+                <xs:element ref="docbook:task"/>
+                <xs:element ref="docbook:productionset"/>
+                <xs:element ref="docbook:constraintdef"/>
+                <xs:element ref="docbook:msgset"/>
+                <xs:element ref="docbook:screen"/>
+                <xs:element ref="docbook:literallayout"/>
+                <xs:element ref="docbook:programlistingco"/>
+                <xs:element ref="docbook:screenco"/>
+                <xs:element ref="docbook:programlisting"/>
+                <xs:element ref="docbook:synopsis"/>
+                <xs:element ref="docbook:bridgehead"/>
+                <xs:element ref="docbook:remark"/>
+                <xs:element ref="docbook:revhistory"/>
+                <xs:element ref="docbook:indexterm"/>
+                <xs:element ref="docbook:funcsynopsis"/>
+                <xs:element ref="docbook:classsynopsis"/>
+                <xs:element ref="docbook:methodsynopsis"/>
+                <xs:element ref="docbook:constructorsynopsis"/>
+                <xs:element ref="docbook:destructorsynopsis"/>
+                <xs:element ref="docbook:fieldsynopsis"/>
+                <xs:element ref="docbook:cmdsynopsis"/>
+                <xs:element ref="docbook:caution"/>
+                <xs:element ref="docbook:important"/>
+                <xs:element ref="docbook:note"/>
+                <xs:element ref="docbook:tip"/>
+                <xs:element ref="docbook:warning"/>
+                <xs:element ref="docbook:anchor"/>
+                <xs:element ref="docbook:para"/>
+                <xs:element ref="docbook:formalpara"/>
+                <xs:element ref="docbook:simpara"/>
+                <xs:element ref="docbook:annotation"/>
+              </xs:choice>
+              <xs:choice minOccurs="0">
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+          </xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="chapter">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+          <xs:choice>
+            <xs:sequence>
+              <xs:choice maxOccurs="unbounded">
+                <xs:element ref="docbook:itemizedlist"/>
+                <xs:element ref="docbook:orderedlist"/>
+                <xs:element ref="docbook:procedure"/>
+                <xs:element ref="docbook:simplelist"/>
+                <xs:element ref="docbook:variablelist"/>
+                <xs:element ref="docbook:segmentedlist"/>
+                <xs:element ref="docbook:glosslist"/>
+                <xs:element ref="docbook:bibliolist"/>
+                <xs:element ref="docbook:calloutlist"/>
+                <xs:element ref="docbook:qandaset"/>
+                <xs:element ref="docbook:example"/>
+                <xs:element ref="docbook:figure"/>
+                <xs:element ref="docbook:table"/>
+                <xs:element ref="docbook:equation"/>
+                <xs:element ref="docbook:informalexample"/>
+                <xs:element ref="docbook:informalfigure"/>
+                <xs:element ref="docbook:informaltable"/>
+                <xs:element ref="docbook:informalequation"/>
+                <xs:element ref="docbook:sidebar"/>
+                <xs:element ref="docbook:blockquote"/>
+                <xs:element ref="docbook:address"/>
+                <xs:element ref="docbook:epigraph"/>
+                <xs:element ref="docbook:mediaobject"/>
+                <xs:element ref="docbook:screenshot"/>
+                <xs:element ref="docbook:task"/>
+                <xs:element ref="docbook:productionset"/>
+                <xs:element ref="docbook:constraintdef"/>
+                <xs:element ref="docbook:msgset"/>
+                <xs:element ref="docbook:screen"/>
+                <xs:element ref="docbook:literallayout"/>
+                <xs:element ref="docbook:programlistingco"/>
+                <xs:element ref="docbook:screenco"/>
+                <xs:element ref="docbook:programlisting"/>
+                <xs:element ref="docbook:synopsis"/>
+                <xs:element ref="docbook:bridgehead"/>
+                <xs:element ref="docbook:remark"/>
+                <xs:element ref="docbook:revhistory"/>
+                <xs:element ref="docbook:indexterm"/>
+                <xs:element ref="docbook:funcsynopsis"/>
+                <xs:element ref="docbook:classsynopsis"/>
+                <xs:element ref="docbook:methodsynopsis"/>
+                <xs:element ref="docbook:constructorsynopsis"/>
+                <xs:element ref="docbook:destructorsynopsis"/>
+                <xs:element ref="docbook:fieldsynopsis"/>
+                <xs:element ref="docbook:cmdsynopsis"/>
+                <xs:element ref="docbook:caution"/>
+                <xs:element ref="docbook:important"/>
+                <xs:element ref="docbook:note"/>
+                <xs:element ref="docbook:tip"/>
+                <xs:element ref="docbook:warning"/>
+                <xs:element ref="docbook:anchor"/>
+                <xs:element ref="docbook:para"/>
+                <xs:element ref="docbook:formalpara"/>
+                <xs:element ref="docbook:simpara"/>
+                <xs:element ref="docbook:annotation"/>
+              </xs:choice>
+              <xs:choice minOccurs="0">
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+          </xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="part">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:partintro"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+          <xs:element ref="docbook:dedication"/>
+          <xs:element ref="docbook:acknowledgements"/>
+          <xs:element ref="docbook:preface"/>
+          <xs:element ref="docbook:chapter"/>
+          <xs:element ref="docbook:appendix"/>
+          <xs:element ref="docbook:article"/>
+          <xs:element ref="docbook:colophon"/>
+          <xs:element ref="docbook:refentry"/>
+          <xs:element ref="docbook:reference"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="preface">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+          <xs:choice>
+            <xs:sequence>
+              <xs:choice maxOccurs="unbounded">
+                <xs:element ref="docbook:itemizedlist"/>
+                <xs:element ref="docbook:orderedlist"/>
+                <xs:element ref="docbook:procedure"/>
+                <xs:element ref="docbook:simplelist"/>
+                <xs:element ref="docbook:variablelist"/>
+                <xs:element ref="docbook:segmentedlist"/>
+                <xs:element ref="docbook:glosslist"/>
+                <xs:element ref="docbook:bibliolist"/>
+                <xs:element ref="docbook:calloutlist"/>
+                <xs:element ref="docbook:qandaset"/>
+                <xs:element ref="docbook:example"/>
+                <xs:element ref="docbook:figure"/>
+                <xs:element ref="docbook:table"/>
+                <xs:element ref="docbook:equation"/>
+                <xs:element ref="docbook:informalexample"/>
+                <xs:element ref="docbook:informalfigure"/>
+                <xs:element ref="docbook:informaltable"/>
+                <xs:element ref="docbook:informalequation"/>
+                <xs:element ref="docbook:sidebar"/>
+                <xs:element ref="docbook:blockquote"/>
+                <xs:element ref="docbook:address"/>
+                <xs:element ref="docbook:epigraph"/>
+                <xs:element ref="docbook:mediaobject"/>
+                <xs:element ref="docbook:screenshot"/>
+                <xs:element ref="docbook:task"/>
+                <xs:element ref="docbook:productionset"/>
+                <xs:element ref="docbook:constraintdef"/>
+                <xs:element ref="docbook:msgset"/>
+                <xs:element ref="docbook:screen"/>
+                <xs:element ref="docbook:literallayout"/>
+                <xs:element ref="docbook:programlistingco"/>
+                <xs:element ref="docbook:screenco"/>
+                <xs:element ref="docbook:programlisting"/>
+                <xs:element ref="docbook:synopsis"/>
+                <xs:element ref="docbook:bridgehead"/>
+                <xs:element ref="docbook:remark"/>
+                <xs:element ref="docbook:revhistory"/>
+                <xs:element ref="docbook:indexterm"/>
+                <xs:element ref="docbook:funcsynopsis"/>
+                <xs:element ref="docbook:classsynopsis"/>
+                <xs:element ref="docbook:methodsynopsis"/>
+                <xs:element ref="docbook:constructorsynopsis"/>
+                <xs:element ref="docbook:destructorsynopsis"/>
+                <xs:element ref="docbook:fieldsynopsis"/>
+                <xs:element ref="docbook:cmdsynopsis"/>
+                <xs:element ref="docbook:caution"/>
+                <xs:element ref="docbook:important"/>
+                <xs:element ref="docbook:note"/>
+                <xs:element ref="docbook:tip"/>
+                <xs:element ref="docbook:warning"/>
+                <xs:element ref="docbook:anchor"/>
+                <xs:element ref="docbook:para"/>
+                <xs:element ref="docbook:formalpara"/>
+                <xs:element ref="docbook:simpara"/>
+                <xs:element ref="docbook:annotation"/>
+              </xs:choice>
+              <xs:choice minOccurs="0">
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+                </xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+              </xs:choice>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+          </xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:glossary"/>
+            <xs:element ref="docbook:bibliography"/>
+            <xs:element ref="docbook:index"/>
+            <xs:element ref="docbook:toc"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="partintro">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="section">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+              <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="simplesect">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+          <xs:element ref="docbook:appendix"/>
+          <xs:element ref="docbook:acknowledgements"/>
+          <xs:element ref="docbook:colophon"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:section"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect1"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+          <xs:element ref="docbook:appendix"/>
+          <xs:element ref="docbook:acknowledgements"/>
+          <xs:element ref="docbook:colophon"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="faq"/>
+            <xs:enumeration value="journalarticle"/>
+            <xs:enumeration value="productsheet"/>
+            <xs:enumeration value="specification"/>
+            <xs:enumeration value="techreport"/>
+            <xs:enumeration value="whitepaper"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attribute name="annotates"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="extendedlink">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:locator"/>
+        <xs:element ref="docbook:arc"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="locator">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute ref="xlink:label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arc">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute ref="xlink:from"/>
+      <xs:attribute ref="xlink:to"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sect1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect2"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect2"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sect2">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect3"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect3"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sect3">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect4"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect4"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sect4">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="docbook:sect5"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+              </xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:sect5"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sect5">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:simplesect"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplesect"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:glossary"/>
+          <xs:element ref="docbook:bibliography"/>
+          <xs:element ref="docbook:index"/>
+          <xs:element ref="docbook:toc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reference">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:partintro"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:refentry"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element minOccurs="0" ref="docbook:refmeta"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:refnamediv"/>
+        <xs:element minOccurs="0" ref="docbook:refsynopsisdiv"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsection"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsect1"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refmeta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+        <xs:element ref="docbook:refentrytitle"/>
+        <xs:element minOccurs="0" ref="docbook:manvolnum"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:refmiscinfo"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refmiscinfo">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="source"/>
+            <xs:enumeration value="version"/>
+            <xs:enumeration value="manual"/>
+            <xs:enumeration value="sectdesc"/>
+            <xs:enumeration value="software"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherclass"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refnamediv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:refdescriptor"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:refname"/>
+        <xs:element ref="docbook:refpurpose"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:refclass"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refdescriptor">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refpurpose">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refclass">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:application"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refsynopsisdiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+              <xs:element maxOccurs="unbounded" ref="docbook:refsection"/>
+              <xs:element maxOccurs="unbounded" ref="docbook:refsect2"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsection"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsect2"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refsection">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:refsection"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsection"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refsect1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:refsect2"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsect2"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refsect2">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element ref="docbook:itemizedlist"/>
+              <xs:element ref="docbook:orderedlist"/>
+              <xs:element ref="docbook:procedure"/>
+              <xs:element ref="docbook:simplelist"/>
+              <xs:element ref="docbook:variablelist"/>
+              <xs:element ref="docbook:segmentedlist"/>
+              <xs:element ref="docbook:glosslist"/>
+              <xs:element ref="docbook:bibliolist"/>
+              <xs:element ref="docbook:calloutlist"/>
+              <xs:element ref="docbook:qandaset"/>
+              <xs:element ref="docbook:example"/>
+              <xs:element ref="docbook:figure"/>
+              <xs:element ref="docbook:table"/>
+              <xs:element ref="docbook:equation"/>
+              <xs:element ref="docbook:informalexample"/>
+              <xs:element ref="docbook:informalfigure"/>
+              <xs:element ref="docbook:informaltable"/>
+              <xs:element ref="docbook:informalequation"/>
+              <xs:element ref="docbook:sidebar"/>
+              <xs:element ref="docbook:blockquote"/>
+              <xs:element ref="docbook:address"/>
+              <xs:element ref="docbook:epigraph"/>
+              <xs:element ref="docbook:mediaobject"/>
+              <xs:element ref="docbook:screenshot"/>
+              <xs:element ref="docbook:task"/>
+              <xs:element ref="docbook:productionset"/>
+              <xs:element ref="docbook:constraintdef"/>
+              <xs:element ref="docbook:msgset"/>
+              <xs:element ref="docbook:screen"/>
+              <xs:element ref="docbook:literallayout"/>
+              <xs:element ref="docbook:programlistingco"/>
+              <xs:element ref="docbook:screenco"/>
+              <xs:element ref="docbook:programlisting"/>
+              <xs:element ref="docbook:synopsis"/>
+              <xs:element ref="docbook:bridgehead"/>
+              <xs:element ref="docbook:remark"/>
+              <xs:element ref="docbook:revhistory"/>
+              <xs:element ref="docbook:indexterm"/>
+              <xs:element ref="docbook:funcsynopsis"/>
+              <xs:element ref="docbook:classsynopsis"/>
+              <xs:element ref="docbook:methodsynopsis"/>
+              <xs:element ref="docbook:constructorsynopsis"/>
+              <xs:element ref="docbook:destructorsynopsis"/>
+              <xs:element ref="docbook:fieldsynopsis"/>
+              <xs:element ref="docbook:cmdsynopsis"/>
+              <xs:element ref="docbook:caution"/>
+              <xs:element ref="docbook:important"/>
+              <xs:element ref="docbook:note"/>
+              <xs:element ref="docbook:tip"/>
+              <xs:element ref="docbook:warning"/>
+              <xs:element ref="docbook:anchor"/>
+              <xs:element ref="docbook:para"/>
+              <xs:element ref="docbook:formalpara"/>
+              <xs:element ref="docbook:simpara"/>
+              <xs:element ref="docbook:annotation"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:refsect3"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="docbook:refsect3"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="refsect3">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glosslist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence minOccurs="0">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:glossentry"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element minOccurs="0" ref="docbook:acronym"/>
+        <xs:element minOccurs="0" ref="docbook:abbrev"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+        <xs:choice>
+          <xs:element ref="docbook:glosssee"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:glossdef"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="sortas"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossdef">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:glossseealso"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="subject"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glosssee">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="otherterm" type="xs:IDREF"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossseealso">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="otherterm" type="xs:IDREF"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="firstterm">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="baseform"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossterm">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="baseform"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossary">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:glossdiv"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:glossentry"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:bibliography"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossdiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:glossentry"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="termdef">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attribute name="sortas"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="baseform"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="biblioentry">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:abstract"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:artpagenums"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:authorgroup"/>
+        <xs:element ref="docbook:authorinitials"/>
+        <xs:element ref="docbook:bibliocoverage"/>
+        <xs:element ref="docbook:biblioid"/>
+        <xs:element ref="docbook:bibliosource"/>
+        <xs:element ref="docbook:collab"/>
+        <xs:element ref="docbook:confgroup"/>
+        <xs:element ref="docbook:contractsponsor"/>
+        <xs:element ref="docbook:contractnum"/>
+        <xs:element ref="docbook:copyright"/>
+        <xs:element ref="docbook:cover"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:edition"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:issuenum"/>
+        <xs:element ref="docbook:keywordset"/>
+        <xs:element ref="docbook:legalnotice"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:othercredit"/>
+        <xs:element ref="docbook:pagenums"/>
+        <xs:element ref="docbook:printhistory"/>
+        <xs:element ref="docbook:pubdate"/>
+        <xs:element ref="docbook:publisher"/>
+        <xs:element ref="docbook:publishername"/>
+        <xs:element ref="docbook:releaseinfo"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:seriesvolnums"/>
+        <xs:element ref="docbook:subjectset"/>
+        <xs:element ref="docbook:volumenum"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:extendedlink"/>
+        <xs:element ref="docbook:bibliomisc"/>
+        <xs:element ref="docbook:bibliomset"/>
+        <xs:element ref="docbook:bibliorelation"/>
+        <xs:element ref="docbook:biblioset"/>
+        <xs:element ref="docbook:itermset"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personblurb"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:subtitle"/>
+        <xs:element ref="docbook:title"/>
+        <xs:element ref="docbook:titleabbrev"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliomixed">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:abstract"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:artpagenums"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:authorgroup"/>
+        <xs:element ref="docbook:authorinitials"/>
+        <xs:element ref="docbook:bibliocoverage"/>
+        <xs:element ref="docbook:biblioid"/>
+        <xs:element ref="docbook:bibliosource"/>
+        <xs:element ref="docbook:collab"/>
+        <xs:element ref="docbook:confgroup"/>
+        <xs:element ref="docbook:contractsponsor"/>
+        <xs:element ref="docbook:contractnum"/>
+        <xs:element ref="docbook:copyright"/>
+        <xs:element ref="docbook:cover"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:edition"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:issuenum"/>
+        <xs:element ref="docbook:keywordset"/>
+        <xs:element ref="docbook:legalnotice"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:othercredit"/>
+        <xs:element ref="docbook:pagenums"/>
+        <xs:element ref="docbook:printhistory"/>
+        <xs:element ref="docbook:pubdate"/>
+        <xs:element ref="docbook:publisher"/>
+        <xs:element ref="docbook:publishername"/>
+        <xs:element ref="docbook:releaseinfo"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:seriesvolnums"/>
+        <xs:element ref="docbook:subjectset"/>
+        <xs:element ref="docbook:volumenum"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:extendedlink"/>
+        <xs:element ref="docbook:bibliomisc"/>
+        <xs:element ref="docbook:bibliomset"/>
+        <xs:element ref="docbook:bibliorelation"/>
+        <xs:element ref="docbook:biblioset"/>
+        <xs:element ref="docbook:itermset"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personblurb"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:subtitle"/>
+        <xs:element ref="docbook:title"/>
+        <xs:element ref="docbook:titleabbrev"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="biblioset">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:abstract"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:artpagenums"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:authorgroup"/>
+        <xs:element ref="docbook:authorinitials"/>
+        <xs:element ref="docbook:bibliocoverage"/>
+        <xs:element ref="docbook:biblioid"/>
+        <xs:element ref="docbook:bibliosource"/>
+        <xs:element ref="docbook:collab"/>
+        <xs:element ref="docbook:confgroup"/>
+        <xs:element ref="docbook:contractsponsor"/>
+        <xs:element ref="docbook:contractnum"/>
+        <xs:element ref="docbook:copyright"/>
+        <xs:element ref="docbook:cover"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:edition"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:issuenum"/>
+        <xs:element ref="docbook:keywordset"/>
+        <xs:element ref="docbook:legalnotice"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:othercredit"/>
+        <xs:element ref="docbook:pagenums"/>
+        <xs:element ref="docbook:printhistory"/>
+        <xs:element ref="docbook:pubdate"/>
+        <xs:element ref="docbook:publisher"/>
+        <xs:element ref="docbook:publishername"/>
+        <xs:element ref="docbook:releaseinfo"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:seriesvolnums"/>
+        <xs:element ref="docbook:subjectset"/>
+        <xs:element ref="docbook:volumenum"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:extendedlink"/>
+        <xs:element ref="docbook:bibliomisc"/>
+        <xs:element ref="docbook:bibliomset"/>
+        <xs:element ref="docbook:bibliorelation"/>
+        <xs:element ref="docbook:biblioset"/>
+        <xs:element ref="docbook:itermset"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personblurb"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:subtitle"/>
+        <xs:element ref="docbook:title"/>
+        <xs:element ref="docbook:titleabbrev"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="relation"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliomset">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:abstract"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:artpagenums"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:authorgroup"/>
+        <xs:element ref="docbook:authorinitials"/>
+        <xs:element ref="docbook:bibliocoverage"/>
+        <xs:element ref="docbook:biblioid"/>
+        <xs:element ref="docbook:bibliosource"/>
+        <xs:element ref="docbook:collab"/>
+        <xs:element ref="docbook:confgroup"/>
+        <xs:element ref="docbook:contractsponsor"/>
+        <xs:element ref="docbook:contractnum"/>
+        <xs:element ref="docbook:copyright"/>
+        <xs:element ref="docbook:cover"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:edition"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:issuenum"/>
+        <xs:element ref="docbook:keywordset"/>
+        <xs:element ref="docbook:legalnotice"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:othercredit"/>
+        <xs:element ref="docbook:pagenums"/>
+        <xs:element ref="docbook:printhistory"/>
+        <xs:element ref="docbook:pubdate"/>
+        <xs:element ref="docbook:publisher"/>
+        <xs:element ref="docbook:publishername"/>
+        <xs:element ref="docbook:releaseinfo"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:seriesvolnums"/>
+        <xs:element ref="docbook:subjectset"/>
+        <xs:element ref="docbook:volumenum"/>
+        <xs:element ref="docbook:extendedlink"/>
+        <xs:element ref="docbook:bibliomisc"/>
+        <xs:element ref="docbook:bibliomset"/>
+        <xs:element ref="docbook:bibliorelation"/>
+        <xs:element ref="docbook:biblioset"/>
+        <xs:element ref="docbook:itermset"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personblurb"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:subtitle"/>
+        <xs:element ref="docbook:title"/>
+        <xs:element ref="docbook:titleabbrev"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="relation"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliomisc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliography">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:bibliodiv"/>
+          <xs:choice maxOccurs="unbounded">
+            <xs:element ref="docbook:biblioentry"/>
+            <xs:element ref="docbook:bibliomixed"/>
+          </xs:choice>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliodiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:biblioentry"/>
+          <xs:element ref="docbook:bibliomixed"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bibliolist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence minOccurs="0">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:biblioentry"/>
+          <xs:element ref="docbook:bibliomixed"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="biblioref">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="xrefstyle"/>
+      <xs:attribute name="endterm" type="xs:IDREF"/>
+      <xs:attribute name="units" type="xs:NMTOKEN"/>
+      <xs:attribute name="begin" type="xs:NMTOKEN"/>
+      <xs:attribute name="end" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="itermset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:indexterm"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="indexterm">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:primary"/>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element ref="docbook:secondary"/>
+            <xs:choice minOccurs="0">
+              <xs:sequence>
+                <xs:element ref="docbook:tertiary"/>
+                <xs:choice minOccurs="0">
+                  <xs:element ref="docbook:see"/>
+                  <xs:element maxOccurs="unbounded" ref="docbook:seealso"/>
+                </xs:choice>
+              </xs:sequence>
+              <xs:element ref="docbook:see"/>
+              <xs:element maxOccurs="unbounded" ref="docbook:seealso"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:element ref="docbook:see"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:seealso"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="significance">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="preferred"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startref" type="xs:IDREF"/>
+      <xs:attribute name="zone" type="xs:IDREFS"/>
+      <xs:attribute name="pagenum"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="global"/>
+            <xs:enumeration value="local"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="singular"/>
+            <xs:enumeration value="startofrange"/>
+            <xs:enumeration value="endofrange"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="primary">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="sortas"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="secondary">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="sortas"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tertiary">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="sortas"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="see">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seealso">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="index">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexdiv"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexentry"/>
+          <xs:element ref="docbook:segmentedlist"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="setindex">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexdiv"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+      <xs:attribute name="type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="indexdiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:indexentry"/>
+          <xs:element ref="docbook:segmentedlist"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="indexentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:primaryie"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:seeie"/>
+          <xs:element ref="docbook:seealsoie"/>
+        </xs:choice>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:secondaryie"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:seeie"/>
+            <xs:element ref="docbook:seealsoie"/>
+            <xs:element ref="docbook:tertiaryie"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="primaryie">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="secondaryie">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tertiaryie">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seeie">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="seealsoie">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="toc">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:tocdiv"/>
+          <xs:element ref="docbook:tocentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tocdiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:tocdiv"/>
+          <xs:element ref="docbook:tocentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="pagenum"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tocentry">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="pagenum"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="task">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+            <xs:element ref="docbook:subtitle"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:tasksummary"/>
+        <xs:element minOccurs="0" ref="docbook:taskprerequisites"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:example"/>
+        <xs:element minOccurs="0" ref="docbook:taskrelated"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tasksummary">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="taskprerequisites">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="taskrelated">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="calloutlist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:callout"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="callout">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="arearefs" use="required" type="xs:IDREFS"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="programlistingco">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:areaspec"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:calloutlist"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="areaspec">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:area"/>
+        <xs:element ref="docbook:areaset"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="units">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="calspair"/>
+            <xs:enumeration value="linecolumn"/>
+            <xs:enumeration value="linecolumnpair"/>
+            <xs:enumeration value="linerange"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherunits" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="area">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="units">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="calspair"/>
+            <xs:enumeration value="linecolumn"/>
+            <xs:enumeration value="linecolumnpair"/>
+            <xs:enumeration value="linerange"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherunits" type="xs:NMTOKEN"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="coords" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="areaset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:area"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="units">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="calspair"/>
+            <xs:enumeration value="linecolumn"/>
+            <xs:enumeration value="linecolumnpair"/>
+            <xs:enumeration value="linerange"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherunits" type="xs:NMTOKEN"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="screenco">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:areaspec"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:calloutlist"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="imageobjectco">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element ref="docbook:areaspec"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:imageobject"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:calloutlist"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="co">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="linkends" type="xs:IDREFS"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="coref">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="productionset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:production"/>
+          <xs:element ref="docbook:productionrecap"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="production">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:lhs"/>
+        <xs:element ref="docbook:rhs"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:constraint"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lhs">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rhs">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:sbr"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="nonterminal">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="def" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="constraint">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="productionrecap">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="constraintdef">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tgroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colspec"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:spanspec"/>
+        <xs:element minOccurs="0" ref="docbook:thead"/>
+        <xs:element minOccurs="0" ref="docbook:tfoot"/>
+        <xs:element ref="docbook:tbody"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="tgroupstyle"/>
+      <xs:attribute name="cols" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="colspec">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="colnum" type="xs:NMTOKEN"/>
+      <xs:attribute name="char"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="colwidth"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="spanspec">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="spanname" use="required"/>
+      <xs:attribute name="namest" use="required"/>
+      <xs:attribute name="nameend" use="required"/>
+      <xs:attribute name="char"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colspec"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:row"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colspec"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:row"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element maxOccurs="unbounded" ref="docbook:row"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:tr"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="row">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:entry"/>
+        <xs:element ref="docbook:entrytbl"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entry">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="morerows" type="xs:NMTOKEN"/>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="namest"/>
+      <xs:attribute name="spanname"/>
+      <xs:attribute name="nameend"/>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rotate">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entrytbl">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colspec"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:spanspec"/>
+        <xs:element minOccurs="0" ref="docbook:thead"/>
+        <xs:element ref="docbook:tbody"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="colname"/>
+      <xs:attribute name="namest"/>
+      <xs:attribute name="spanname"/>
+      <xs:attribute name="nameend"/>
+      <xs:attribute name="tgroupstyle"/>
+      <xs:attribute name="cols" type="xs:NMTOKEN"/>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="char"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+          <xs:sequence>
+            <xs:element ref="docbook:title"/>
+            <xs:element minOccurs="0" ref="docbook:titleabbrev"/>
+          </xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:indexterm"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:textobject"/>
+          <xs:choice>
+            <xs:element maxOccurs="unbounded" ref="docbook:mediaobject"/>
+            <xs:element maxOccurs="unbounded" ref="docbook:tgroup"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element ref="docbook:caption"/>
+          <xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:col"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colgroup"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:thead"/>
+          <xs:element minOccurs="0" ref="docbook:tfoot"/>
+          <xs:choice>
+            <xs:element maxOccurs="unbounded" ref="docbook:tbody"/>
+            <xs:element maxOccurs="unbounded" ref="docbook:tr"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attribute name="label"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="tabstyle"/>
+      <xs:attribute name="floatstyle"/>
+      <xs:attribute name="orient">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="land"/>
+            <xs:enumeration value="port"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="sides"/>
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="topbot"/>
+            <xs:enumeration value="void"/>
+            <xs:enumeration value="above"/>
+            <xs:enumeration value="below"/>
+            <xs:enumeration value="hsides"/>
+            <xs:enumeration value="lhs"/>
+            <xs:enumeration value="rhs"/>
+            <xs:enumeration value="vsides"/>
+            <xs:enumeration value="box"/>
+            <xs:enumeration value="border"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="shortentry">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tocentry">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowheader">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="firstcol"/>
+            <xs:enumeration value="norowheader"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="summary"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="border" type="xs:NMTOKEN"/>
+      <xs:attribute name="rules">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="groups"/>
+            <xs:enumeration value="rows"/>
+            <xs:enumeration value="cols"/>
+            <xs:enumeration value="all"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="cellspacing"/>
+      <xs:attribute name="cellpadding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="informaltable">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:textobject"/>
+            <xs:choice>
+              <xs:element maxOccurs="unbounded" ref="docbook:mediaobject"/>
+              <xs:element maxOccurs="unbounded" ref="docbook:tgroup"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:choice>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:col"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:colgroup"/>
+            </xs:choice>
+            <xs:element minOccurs="0" ref="docbook:thead"/>
+            <xs:element minOccurs="0" ref="docbook:tfoot"/>
+            <xs:choice>
+              <xs:element maxOccurs="unbounded" ref="docbook:tbody"/>
+              <xs:element maxOccurs="unbounded" ref="docbook:tr"/>
+            </xs:choice>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="tabstyle"/>
+      <xs:attribute name="floatstyle"/>
+      <xs:attribute name="orient">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="land"/>
+            <xs:enumeration value="port"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="colsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowsep">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="sides"/>
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="topbot"/>
+            <xs:enumeration value="void"/>
+            <xs:enumeration value="above"/>
+            <xs:enumeration value="below"/>
+            <xs:enumeration value="hsides"/>
+            <xs:enumeration value="lhs"/>
+            <xs:enumeration value="rhs"/>
+            <xs:enumeration value="vsides"/>
+            <xs:enumeration value="box"/>
+            <xs:enumeration value="border"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowheader">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="firstcol"/>
+            <xs:enumeration value="norowheader"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="summary"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="border" type="xs:NMTOKEN"/>
+      <xs:attribute name="rules">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="groups"/>
+            <xs:enumeration value="rows"/>
+            <xs:enumeration value="cols"/>
+            <xs:enumeration value="all"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="cellspacing"/>
+      <xs:attribute name="cellpadding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="col">
+    <xs:complexType>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="span" type="xs:NMTOKEN"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="colgroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:col"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="span" type="xs:NMTOKEN"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:th"/>
+        <xs:element ref="docbook:td"/>
+      </xs:choice>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+      </xs:choice>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="abbr"/>
+      <xs:attribute name="axis"/>
+      <xs:attribute name="headers"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="row"/>
+            <xs:enumeration value="col"/>
+            <xs:enumeration value="rowgroup"/>
+            <xs:enumeration value="colgroup"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan" type="xs:NMTOKEN"/>
+      <xs:attribute name="colspan" type="xs:NMTOKEN"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+      </xs:choice>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="title"/>
+      <xs:attribute name="lang"/>
+      <xs:attribute name="onclick"/>
+      <xs:attribute name="ondblclick"/>
+      <xs:attribute name="onmousedown"/>
+      <xs:attribute name="onmouseup"/>
+      <xs:attribute name="onmouseover"/>
+      <xs:attribute name="onmousemove"/>
+      <xs:attribute name="onmouseout"/>
+      <xs:attribute name="onkeypress"/>
+      <xs:attribute name="onkeydown"/>
+      <xs:attribute name="onkeyup"/>
+      <xs:attribute name="abbr"/>
+      <xs:attribute name="axis"/>
+      <xs:attribute name="headers"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="row"/>
+            <xs:enumeration value="col"/>
+            <xs:enumeration value="rowgroup"/>
+            <xs:enumeration value="colgroup"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan" type="xs:NMTOKEN"/>
+      <xs:attribute name="colspan" type="xs:NMTOKEN"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:msgentry"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:simplemsgentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="docbook:msg"/>
+        <xs:element minOccurs="0" ref="docbook:msginfo"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:msgexplan"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="simplemsgentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="docbook:msgtext"/>
+        <xs:element maxOccurs="unbounded" ref="docbook:msgexplan"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="msgaud"/>
+      <xs:attribute name="msgorig"/>
+      <xs:attribute name="msglevel"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msg">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:msgmain"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:msgsub"/>
+          <xs:element ref="docbook:msgrel"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgmain">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:msgtext"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgsub">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:msgtext"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgrel">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:msgtext"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgtext">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:itemizedlist"/>
+        <xs:element ref="docbook:orderedlist"/>
+        <xs:element ref="docbook:procedure"/>
+        <xs:element ref="docbook:simplelist"/>
+        <xs:element ref="docbook:variablelist"/>
+        <xs:element ref="docbook:segmentedlist"/>
+        <xs:element ref="docbook:glosslist"/>
+        <xs:element ref="docbook:bibliolist"/>
+        <xs:element ref="docbook:calloutlist"/>
+        <xs:element ref="docbook:qandaset"/>
+        <xs:element ref="docbook:example"/>
+        <xs:element ref="docbook:figure"/>
+        <xs:element ref="docbook:table"/>
+        <xs:element ref="docbook:equation"/>
+        <xs:element ref="docbook:informalexample"/>
+        <xs:element ref="docbook:informalfigure"/>
+        <xs:element ref="docbook:informaltable"/>
+        <xs:element ref="docbook:informalequation"/>
+        <xs:element ref="docbook:sidebar"/>
+        <xs:element ref="docbook:blockquote"/>
+        <xs:element ref="docbook:address"/>
+        <xs:element ref="docbook:epigraph"/>
+        <xs:element ref="docbook:mediaobject"/>
+        <xs:element ref="docbook:screenshot"/>
+        <xs:element ref="docbook:task"/>
+        <xs:element ref="docbook:productionset"/>
+        <xs:element ref="docbook:constraintdef"/>
+        <xs:element ref="docbook:msgset"/>
+        <xs:element ref="docbook:screen"/>
+        <xs:element ref="docbook:literallayout"/>
+        <xs:element ref="docbook:programlistingco"/>
+        <xs:element ref="docbook:screenco"/>
+        <xs:element ref="docbook:programlisting"/>
+        <xs:element ref="docbook:synopsis"/>
+        <xs:element ref="docbook:bridgehead"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:revhistory"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:funcsynopsis"/>
+        <xs:element ref="docbook:classsynopsis"/>
+        <xs:element ref="docbook:methodsynopsis"/>
+        <xs:element ref="docbook:constructorsynopsis"/>
+        <xs:element ref="docbook:destructorsynopsis"/>
+        <xs:element ref="docbook:fieldsynopsis"/>
+        <xs:element ref="docbook:cmdsynopsis"/>
+        <xs:element ref="docbook:caution"/>
+        <xs:element ref="docbook:important"/>
+        <xs:element ref="docbook:note"/>
+        <xs:element ref="docbook:tip"/>
+        <xs:element ref="docbook:warning"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:para"/>
+        <xs:element ref="docbook:formalpara"/>
+        <xs:element ref="docbook:simpara"/>
+        <xs:element ref="docbook:annotation"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msginfo">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:msglevel"/>
+        <xs:element ref="docbook:msgorig"/>
+        <xs:element ref="docbook:msgaud"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msglevel">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgorig">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgaud">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="msgexplan">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="qandaset">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:qandadiv"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:qandaentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="defaultlabel">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="number"/>
+            <xs:enumeration value="qanda"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="qandadiv">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:qandadiv"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:qandaentry"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="qandaentry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element ref="docbook:question"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:answer"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="question">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:label"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="answer">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:label"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="label">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:mediaobject"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:mathphrase"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="label"/>
+      <xs:attribute name="pgwide">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="floatstyle"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="informalequation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:mediaobject"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:mathphrase"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="docbook:caption"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inlineequation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:alt"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:inlinemediaobject"/>
+          <xs:element maxOccurs="unbounded" ref="docbook:mathphrase"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mathphrase">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:emphasis"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="markup">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tag">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="attribute"/>
+            <xs:enumeration value="attvalue"/>
+            <xs:enumeration value="element"/>
+            <xs:enumeration value="emptytag"/>
+            <xs:enumeration value="endtag"/>
+            <xs:enumeration value="genentity"/>
+            <xs:enumeration value="localname"/>
+            <xs:enumeration value="namespace"/>
+            <xs:enumeration value="numcharref"/>
+            <xs:enumeration value="paramentity"/>
+            <xs:enumeration value="pi"/>
+            <xs:enumeration value="prefix"/>
+            <xs:enumeration value="comment"/>
+            <xs:enumeration value="starttag"/>
+            <xs:enumeration value="xmlpi"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="namespace"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="symbol">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="limit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="token">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="literal">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="code">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="constant">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="limit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="productname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="copyright"/>
+            <xs:enumeration value="registered"/>
+            <xs:enumeration value="service"/>
+            <xs:enumeration value="trade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="productnumber">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="database">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="altkey"/>
+            <xs:enumeration value="constraint"/>
+            <xs:enumeration value="datatype"/>
+            <xs:enumeration value="field"/>
+            <xs:enumeration value="foreignkey"/>
+            <xs:enumeration value="group"/>
+            <xs:enumeration value="index"/>
+            <xs:enumeration value="key1"/>
+            <xs:enumeration value="key2"/>
+            <xs:enumeration value="name"/>
+            <xs:enumeration value="primarykey"/>
+            <xs:enumeration value="procedure"/>
+            <xs:enumeration value="record"/>
+            <xs:enumeration value="rule"/>
+            <xs:enumeration value="secondarykey"/>
+            <xs:enumeration value="table"/>
+            <xs:enumeration value="user"/>
+            <xs:enumeration value="view"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="application">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="hardware"/>
+            <xs:enumeration value="software"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="hardware">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guibutton">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guiicon">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guilabel">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guimenu">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guimenuitem">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="guisubmenu">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="menuchoice">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:shortcut"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:guibutton"/>
+          <xs:element ref="docbook:guiicon"/>
+          <xs:element ref="docbook:guilabel"/>
+          <xs:element ref="docbook:guimenu"/>
+          <xs:element ref="docbook:guimenuitem"/>
+          <xs:element ref="docbook:guisubmenu"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mousebutton">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keycap">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="function">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="alt"/>
+            <xs:enumeration value="backspace"/>
+            <xs:enumeration value="command"/>
+            <xs:enumeration value="control"/>
+            <xs:enumeration value="delete"/>
+            <xs:enumeration value="down"/>
+            <xs:enumeration value="end"/>
+            <xs:enumeration value="enter"/>
+            <xs:enumeration value="escape"/>
+            <xs:enumeration value="home"/>
+            <xs:enumeration value="insert"/>
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="meta"/>
+            <xs:enumeration value="option"/>
+            <xs:enumeration value="pagedown"/>
+            <xs:enumeration value="pageup"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="shift"/>
+            <xs:enumeration value="space"/>
+            <xs:enumeration value="tab"/>
+            <xs:enumeration value="up"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otherfunction"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keycode">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keycombo">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:mousebutton"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="action">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="click"/>
+            <xs:enumeration value="double-click"/>
+            <xs:enumeration value="press"/>
+            <xs:enumeration value="seq"/>
+            <xs:enumeration value="simul"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otheraction"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keysym">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="accel">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="shortcut">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:mousebutton"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="action">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="click"/>
+            <xs:enumeration value="double-click"/>
+            <xs:enumeration value="press"/>
+            <xs:enumeration value="seq"/>
+            <xs:enumeration value="simul"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="otheraction"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="prompt">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="envar">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="filename">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="path"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="devicefile"/>
+            <xs:enumeration value="directory"/>
+            <xs:enumeration value="extension"/>
+            <xs:enumeration value="headerfile"/>
+            <xs:enumeration value="libraryfile"/>
+            <xs:enumeration value="partition"/>
+            <xs:enumeration value="symlink"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="command">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="computeroutput">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:co"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="userinput">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:co"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cmdsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:command"/>
+          <xs:element ref="docbook:arg"/>
+          <xs:element ref="docbook:group"/>
+          <xs:element ref="docbook:sbr"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:synopfragment"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="sepchar"/>
+      <xs:attribute name="cmdlength"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arg">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:arg"/>
+        <xs:element ref="docbook:group"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:synopfragmentref"/>
+        <xs:element ref="docbook:sbr"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="rep" default="norepeat">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="norepeat"/>
+            <xs:enumeration value="repeat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="choice" default="opt">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="opt"/>
+            <xs:enumeration value="plain"/>
+            <xs:enumeration value="req"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:arg"/>
+        <xs:element ref="docbook:group"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:synopfragmentref"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:sbr"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="rep" default="norepeat">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="norepeat"/>
+            <xs:enumeration value="repeat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="choice" default="opt">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="opt"/>
+            <xs:enumeration value="plain"/>
+            <xs:enumeration value="req"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sbr">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="synopfragment">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="docbook:arg"/>
+        <xs:element ref="docbook:group"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="synopfragmentref">
+    <xs:complexType mixed="true">
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="synopsis">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+      <xs:attribute name="label"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funcsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="docbook:info"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:funcsynopsisinfo"/>
+          <xs:element ref="docbook:funcprototype"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funcsynopsisinfo">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funcprototype">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+        <xs:element ref="docbook:funcdef"/>
+        <xs:choice>
+          <xs:element ref="docbook:void"/>
+          <xs:element ref="docbook:varargs"/>
+          <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="docbook:paramdef"/>
+            <xs:element minOccurs="0" ref="docbook:varargs"/>
+          </xs:sequence>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funcdef">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:function"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="function">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="void">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="varargs">
+    <xs:complexType>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="paramdef">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:funcparams"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="choice" default="opt">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="opt"/>
+            <xs:enumeration value="req"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funcparams">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="classsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:ooclass"/>
+          <xs:element ref="docbook:ooexception"/>
+          <xs:element ref="docbook:oointerface"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:classsynopsisinfo"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="class"/>
+            <xs:enumeration value="interface"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="classsynopsisinfo">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ooclass">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:package"/>
+          <xs:element ref="docbook:modifier"/>
+        </xs:choice>
+        <xs:element ref="docbook:classname"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="oointerface">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:package"/>
+          <xs:element ref="docbook:modifier"/>
+        </xs:choice>
+        <xs:element ref="docbook:interfacename"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ooexception">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:package"/>
+          <xs:element ref="docbook:modifier"/>
+        </xs:choice>
+        <xs:element ref="docbook:exceptionname"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="modifier">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute ref="xml:space"/>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="interfacename">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exceptionname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fieldsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+        <xs:element minOccurs="0" ref="docbook:type"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element minOccurs="0" ref="docbook:initializer"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="initializer">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="constructorsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+        <xs:element minOccurs="0" ref="docbook:methodname"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:methodparam"/>
+          <xs:element minOccurs="0" ref="docbook:void"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:exceptionname"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="destructorsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+        <xs:element minOccurs="0" ref="docbook:methodname"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:methodparam"/>
+          <xs:element minOccurs="0" ref="docbook:void"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:exceptionname"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="methodsynopsis">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+        <xs:choice minOccurs="0">
+          <xs:element ref="docbook:type"/>
+          <xs:element ref="docbook:void"/>
+        </xs:choice>
+        <xs:element ref="docbook:methodname"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="docbook:methodparam"/>
+          <xs:element ref="docbook:void"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:exceptionname"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="language"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="methodname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="methodparam">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="docbook:modifier"/>
+          <xs:element ref="docbook:type"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="docbook:parameter"/>
+            <xs:element minOccurs="0" ref="docbook:initializer"/>
+          </xs:sequence>
+          <xs:element ref="docbook:funcparams"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="docbook:modifier"/>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="rep" default="norepeat">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="norepeat"/>
+            <xs:enumeration value="repeat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="choice" default="req">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="opt"/>
+            <xs:enumeration value="plain"/>
+            <xs:enumeration value="req"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="varname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="returnvalue">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="type">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="classname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="programlisting">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:info"/>
+        <xs:element ref="docbook:textobject"/>
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:abbrev"/>
+        <xs:element ref="docbook:acronym"/>
+        <xs:element ref="docbook:date"/>
+        <xs:element ref="docbook:emphasis"/>
+        <xs:element ref="docbook:footnote"/>
+        <xs:element ref="docbook:footnoteref"/>
+        <xs:element ref="docbook:foreignphrase"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:quote"/>
+        <xs:element ref="docbook:wordasword"/>
+        <xs:element ref="docbook:firstterm"/>
+        <xs:element ref="docbook:glossterm"/>
+        <xs:element ref="docbook:coref"/>
+        <xs:element ref="docbook:trademark"/>
+        <xs:element ref="docbook:productnumber"/>
+        <xs:element ref="docbook:productname"/>
+        <xs:element ref="docbook:database"/>
+        <xs:element ref="docbook:application"/>
+        <xs:element ref="docbook:hardware"/>
+        <xs:element ref="docbook:citation"/>
+        <xs:element ref="docbook:citerefentry"/>
+        <xs:element ref="docbook:citetitle"/>
+        <xs:element ref="docbook:citebiblioid"/>
+        <xs:element ref="docbook:author"/>
+        <xs:element ref="docbook:person"/>
+        <xs:element ref="docbook:personname"/>
+        <xs:element ref="docbook:org"/>
+        <xs:element ref="docbook:orgname"/>
+        <xs:element ref="docbook:editor"/>
+        <xs:element ref="docbook:jobtitle"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:package"/>
+        <xs:element ref="docbook:parameter"/>
+        <xs:element ref="docbook:termdef"/>
+        <xs:element ref="docbook:nonterminal"/>
+        <xs:element ref="docbook:systemitem"/>
+        <xs:element ref="docbook:option"/>
+        <xs:element ref="docbook:optional"/>
+        <xs:element ref="docbook:property"/>
+        <xs:element ref="docbook:inlineequation"/>
+        <xs:element ref="docbook:tag"/>
+        <xs:element ref="docbook:markup"/>
+        <xs:element ref="docbook:token"/>
+        <xs:element ref="docbook:symbol"/>
+        <xs:element ref="docbook:literal"/>
+        <xs:element ref="docbook:code"/>
+        <xs:element ref="docbook:constant"/>
+        <xs:element ref="docbook:email"/>
+        <xs:element ref="docbook:uri"/>
+        <xs:element ref="docbook:guiicon"/>
+        <xs:element ref="docbook:guibutton"/>
+        <xs:element ref="docbook:guimenuitem"/>
+        <xs:element ref="docbook:guimenu"/>
+        <xs:element ref="docbook:guisubmenu"/>
+        <xs:element ref="docbook:guilabel"/>
+        <xs:element ref="docbook:menuchoice"/>
+        <xs:element ref="docbook:mousebutton"/>
+        <xs:element ref="docbook:keycombo"/>
+        <xs:element ref="docbook:keycap"/>
+        <xs:element ref="docbook:keycode"/>
+        <xs:element ref="docbook:keysym"/>
+        <xs:element ref="docbook:shortcut"/>
+        <xs:element ref="docbook:accel"/>
+        <xs:element ref="docbook:prompt"/>
+        <xs:element ref="docbook:envar"/>
+        <xs:element ref="docbook:filename"/>
+        <xs:element ref="docbook:command"/>
+        <xs:element ref="docbook:computeroutput"/>
+        <xs:element ref="docbook:userinput"/>
+        <xs:element ref="docbook:function"/>
+        <xs:element ref="docbook:varname"/>
+        <xs:element ref="docbook:returnvalue"/>
+        <xs:element ref="docbook:type"/>
+        <xs:element ref="docbook:classname"/>
+        <xs:element ref="docbook:exceptionname"/>
+        <xs:element ref="docbook:interfacename"/>
+        <xs:element ref="docbook:methodname"/>
+        <xs:element ref="docbook:modifier"/>
+        <xs:element ref="docbook:initializer"/>
+        <xs:element ref="docbook:ooclass"/>
+        <xs:element ref="docbook:ooexception"/>
+        <xs:element ref="docbook:oointerface"/>
+        <xs:element ref="docbook:errorcode"/>
+        <xs:element ref="docbook:errortext"/>
+        <xs:element ref="docbook:errorname"/>
+        <xs:element ref="docbook:errortype"/>
+        <xs:element ref="docbook:lineannotation"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="continuation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="continues"/>
+            <xs:enumeration value="restarts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linenumbering">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numbered"/>
+            <xs:enumeration value="unnumbered"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="startinglinenumber" type="xs:NMTOKEN"/>
+      <xs:attribute name="language"/>
+      <xs:attribute ref="xml:space"/>
+      <xs:attribute name="width" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="caution">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="important">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="note">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tip">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="warning">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="docbook:title"/>
+            <xs:element ref="docbook:titleabbrev"/>
+          </xs:choice>
+          <xs:element minOccurs="0" ref="docbook:info"/>
+        </xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="docbook:itemizedlist"/>
+          <xs:element ref="docbook:orderedlist"/>
+          <xs:element ref="docbook:procedure"/>
+          <xs:element ref="docbook:simplelist"/>
+          <xs:element ref="docbook:variablelist"/>
+          <xs:element ref="docbook:segmentedlist"/>
+          <xs:element ref="docbook:glosslist"/>
+          <xs:element ref="docbook:bibliolist"/>
+          <xs:element ref="docbook:calloutlist"/>
+          <xs:element ref="docbook:qandaset"/>
+          <xs:element ref="docbook:example"/>
+          <xs:element ref="docbook:figure"/>
+          <xs:element ref="docbook:table"/>
+          <xs:element ref="docbook:equation"/>
+          <xs:element ref="docbook:informalexample"/>
+          <xs:element ref="docbook:informalfigure"/>
+          <xs:element ref="docbook:informaltable"/>
+          <xs:element ref="docbook:informalequation"/>
+          <xs:element ref="docbook:sidebar"/>
+          <xs:element ref="docbook:blockquote"/>
+          <xs:element ref="docbook:address"/>
+          <xs:element ref="docbook:epigraph"/>
+          <xs:element ref="docbook:mediaobject"/>
+          <xs:element ref="docbook:screenshot"/>
+          <xs:element ref="docbook:task"/>
+          <xs:element ref="docbook:productionset"/>
+          <xs:element ref="docbook:constraintdef"/>
+          <xs:element ref="docbook:msgset"/>
+          <xs:element ref="docbook:screen"/>
+          <xs:element ref="docbook:literallayout"/>
+          <xs:element ref="docbook:programlistingco"/>
+          <xs:element ref="docbook:screenco"/>
+          <xs:element ref="docbook:programlisting"/>
+          <xs:element ref="docbook:synopsis"/>
+          <xs:element ref="docbook:bridgehead"/>
+          <xs:element ref="docbook:remark"/>
+          <xs:element ref="docbook:revhistory"/>
+          <xs:element ref="docbook:indexterm"/>
+          <xs:element ref="docbook:funcsynopsis"/>
+          <xs:element ref="docbook:classsynopsis"/>
+          <xs:element ref="docbook:methodsynopsis"/>
+          <xs:element ref="docbook:constructorsynopsis"/>
+          <xs:element ref="docbook:destructorsynopsis"/>
+          <xs:element ref="docbook:fieldsynopsis"/>
+          <xs:element ref="docbook:cmdsynopsis"/>
+          <xs:element ref="docbook:caution"/>
+          <xs:element ref="docbook:important"/>
+          <xs:element ref="docbook:note"/>
+          <xs:element ref="docbook:tip"/>
+          <xs:element ref="docbook:warning"/>
+          <xs:element ref="docbook:anchor"/>
+          <xs:element ref="docbook:para"/>
+          <xs:element ref="docbook:formalpara"/>
+          <xs:element ref="docbook:simpara"/>
+          <xs:element ref="docbook:annotation"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="errorcode">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="errorname">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="errortext">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="errortype">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="systemitem">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+        <xs:element ref="docbook:co"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+      <xs:attribute name="class">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="daemon"/>
+            <xs:enumeration value="domainname"/>
+            <xs:enumeration value="etheraddress"/>
+            <xs:enumeration value="event"/>
+            <xs:enumeration value="eventhandler"/>
+            <xs:enumeration value="filesystem"/>
+            <xs:enumeration value="fqdomainname"/>
+            <xs:enumeration value="groupname"/>
+            <xs:enumeration value="ipaddress"/>
+            <xs:enumeration value="library"/>
+            <xs:enumeration value="macro"/>
+            <xs:enumeration value="netmask"/>
+            <xs:enumeration value="newsgroup"/>
+            <xs:enumeration value="osname"/>
+            <xs:enumeration value="process"/>
+            <xs:enumeration value="protocol"/>
+            <xs:enumeration value="resource"/>
+            <xs:enumeration value="server"/>
+            <xs:enumeration value="service"/>
+            <xs:enumeration value="systemname"/>
+            <xs:enumeration value="username"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="option">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="optional">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="property">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="docbook:inlinemediaobject"/>
+        <xs:element ref="docbook:remark"/>
+        <xs:element ref="docbook:superscript"/>
+        <xs:element ref="docbook:subscript"/>
+        <xs:element ref="docbook:xref"/>
+        <xs:element ref="docbook:link"/>
+        <xs:element ref="docbook:olink"/>
+        <xs:element ref="docbook:anchor"/>
+        <xs:element ref="docbook:biblioref"/>
+        <xs:element ref="docbook:alt"/>
+        <xs:element ref="docbook:annotation"/>
+        <xs:element ref="docbook:indexterm"/>
+        <xs:element ref="docbook:phrase"/>
+        <xs:element ref="docbook:replaceable"/>
+      </xs:choice>
+      <xs:attribute name="role"/>
+      <xs:attributeGroup ref="docbook:db.common.attributes"/>
+      <xs:attributeGroup ref="docbook:db.common.linking.attributes"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/scripts/xml-schema/xlink.xsd
+++ b/scripts/xml-schema/xlink.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:docbook="http://docbook.org/ns/docbook">
+  <xs:attribute name="href"/>
+  <xs:attribute name="type"/>
+  <xs:attribute name="role"/>
+  <xs:attribute name="arcrole"/>
+  <xs:attribute name="title"/>
+  <xs:attribute name="show">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="new"/>
+        <xs:enumeration value="replace"/>
+        <xs:enumeration value="embed"/>
+        <xs:enumeration value="other"/>
+        <xs:enumeration value="none"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="actuate">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="onLoad"/>
+        <xs:enumeration value="onRequest"/>
+        <xs:enumeration value="other"/>
+        <xs:enumeration value="none"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="label" type="xs:NMTOKEN"/>
+  <xs:attribute name="from" type="xs:NMTOKEN"/>
+  <xs:attribute name="to" type="xs:NMTOKEN"/>
+</xs:schema>

--- a/scripts/xml-schema/xml.xsd
+++ b/scripts/xml-schema/xml.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:docbook="http://docbook.org/ns/docbook">
+  <xs:attribute name="id" type="xs:ID"/>
+  <xs:attribute name="lang"/>
+  <xs:attribute name="base"/>
+  <xs:attribute name="space">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="preserve"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>


### PR DESCRIPTION
Since the DocBook 5 schema is very unlikely to change, we can afford to store it locally. The performance differences are as follows:

When downloading:
* In the office: 1.2 seconds
* At home: 11 seconds

When stored locally:
* In the office: 1.2 seconds
* At home: 1.1 seconds

Disclaimer: My computer in the office is a different one from that at home.

Even if we need to change the schema for Pantheon to work, we can simply update and commit the XSDs in `$REPO_HOME/scripts/xml-schema` and keep on rolling.

Resolves #655.