### PR TITLE
Glossary

### DIFF
--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -68,3 +68,7 @@ include::topics/contributing-labels.adoc[leveloffset=+3]
 == Upstream Runtime Project Development Resources
 
 _TBD_
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/getting-started/master.adoc
+++ b/docs/getting-started/master.adoc
@@ -25,3 +25,7 @@ include::topics/build-and-deploy-process.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-configure-launcher-sso-realm.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/minishift-installation/master.adoc
+++ b/docs/minishift-installation/master.adoc
@@ -28,3 +28,7 @@ include::topics/minishift-install-next-steps.adoc[leveloffset=+1]
 // temporary location for Nexus install
 [appendix]
 include::topics/minishift-install-nexus-setup.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -130,3 +130,7 @@ include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-nodeshift.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -169,3 +169,7 @@ include::topics/sb-tomcat-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/topics/appendix-glossary.adoc
+++ b/docs/topics/appendix-glossary.adoc
@@ -1,0 +1,29 @@
+
+[[glossary]]
+= Glossary
+
+== Product and Project Names
+
+{launcher}:: The web application you launch boosters with.
+
+{OpenShiftLocal}:: An OpenShift cluster running on your machine using Minishift.
+
+== Terms Specific to {launcher}
+
+[glossary_booster]
+Booster:: An language-specific implementation of a particular xref:glossary_mission[mission] on a particular xref:glossary_runtime[runtime]. Boosters are listed in a xref:glossary_booster_catalog[booster catalog].
++
+For example, a booster is a web service with a REST API implemented using the {WildFlySwarm} runtime.
+
+[[glossary_booster_catalog]]
+Booster Catalog:: A Git repository that contains information about boosters.
+
+[[glossary_mission]]
+Mission:: An application specification, for example _a web service with a REST API._
++
+Missions generally do not specify which language or platform they should run on; the description only contains the intended functionality.
+
+[[glossary_runtime]]
+Runtime:: A platform that executes xref:glossary_booster[boosters].
+For example, {WildFlySwarm} or {VertX}.
+

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -169,3 +169,7 @@ include::topics/vertx-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -168,3 +168,7 @@ include::topics/wf-swarm-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
+
+[appendix]
+include::topics/appendix-glossary.adoc[leveloffset=+1]
+


### PR DESCRIPTION
A short glossary with basic term explanations, all in one place. The explanations are the best I could come up with given my limited knowledge of the product, so please feel free to go to town on them.

The intention is to include the glossary at the end of all books for quick reference.

I have decided against implementing a glossary of terms unrelated to the product just yet, and try to reword the sections those terms if possible instead (see #670). We can discuss this with Ali in regard to long-term content strategy.

Resolves #309.