### PR TITLE
Clarified note in booster description WRT booster ZIP

### DIFF
--- a/docs/topics/note-preview-booster-code.adoc
+++ b/docs/topics/note-preview-booster-code.adoc
@@ -1,1 +1,0 @@
-NOTE: To preview the source code of the Boosters available as part of this Mission, download and extract the link:{link-getting-started-guide}#oso-create-booster[ZIP file] of the Booster for the runtime of your choice.   

--- a/docs/topics/note-preview-booster-source.adoc
+++ b/docs/topics/note-preview-booster-source.adoc
@@ -1,1 +1,2 @@
-NOTE: To view the source code and README file of this Booster, link:{link-getting-started-guide}#oso-create-booster[download and extract the Booster ZIP file].
+NOTE: To view the source code and README file of this booster, download and extract the ZIP file with the booster.
+To get the download link of the ZIP file, follow the instructions in the link:{link-getting-started-guide}#oso-create-booster[Using OpenShift to Create a Booster] chapter of the {getting-started-guide-name}.


### PR DESCRIPTION
I have also deleted the `note-preview-booster-code.adoc` file, which doesn't seem to be used neither by the launchpad frontend, nor by any other file in our repo.

Resolves #671.